### PR TITLE
Constrain regex request-target matching

### DIFF
--- a/h11/_abnf.py
+++ b/h11/_abnf.py
@@ -51,6 +51,7 @@ field_name = token
 #   https://github.com/python-hyper/h11/issues/57
 # We still don't allow NUL or whitespace, because those are often treated as
 # meta-characters and letting them through can lead to nasty issues like SSRF.
+vchar = r"[\x21-\x7e]"
 vchar_or_obs_text = r"[^\x00\s]"
 field_vchar = vchar_or_obs_text
 field_content = r"{field_vchar}+(?:[ \t]+{field_vchar}+)*".format(**globals())
@@ -77,9 +78,9 @@ header_field = (
 #
 # request-target is complicated (see RFC 7230 sec 5.3) -- could be path, full
 # URL, host+port (for connect), or even "*", but in any case we are guaranteed
-# that it contains no spaces (see sec 3.1.1).
+# that it contists of the visible printing characters.
 method = token
-request_target = r"[^ ]+"
+request_target = r"{vchar}+".format(**globals())
 http_version = r"HTTP/(?P<http_version>[0-9]\.[0-9])"
 request_line = (
     r"(?P<method>{method})"

--- a/h11/_events.py
+++ b/h11/_events.py
@@ -5,8 +5,10 @@
 #
 # Don't subclass these. Stuff will break.
 
+import re
 from . import _headers
-from ._util import bytesify, LocalProtocolError
+from ._abnf import request_target
+from ._util import bytesify, LocalProtocolError, validate
 
 # Everything in __all__ gets re-exported as part of the h11 public API.
 __all__ = [
@@ -18,6 +20,7 @@ __all__ = [
     "ConnectionClosed",
 ]
 
+request_target_re = re.compile(request_target.encode("ascii"))
 
 class _EventBundle(object):
     _fields = []
@@ -130,6 +133,8 @@ class Request(_EventBundle):
             raise LocalProtocolError("Missing mandatory Host: header")
         if host_count > 1:
             raise LocalProtocolError("Found multiple Host: headers")
+
+        validate(request_target_re, self.target, "Illegal target characters")
 
 
 class _ResponseBase(_EventBundle):

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -94,6 +94,15 @@ def test_events():
             headers=[("Host", "a"), ("Foo", "asd\x01\x02\x7f")],
             http_version="1.0")
 
+    # Request target is validated
+    for bad_char in b"\x00\x20\x7f\xee":
+        target = bytearray(b"/")
+        target.append(bad_char)
+        with pytest.raises(LocalProtocolError):
+            Request(method="GET", target=target,
+                    headers=[("Host", "a")],
+                    http_version="1.1")
+
     ir = InformationalResponse(status_code=100, headers=[("Host", "a")])
     assert ir.status_code == 100
     assert ir.headers == [(b"host", b"a")]

--- a/h11/tests/test_io.py
+++ b/h11/tests/test_io.py
@@ -388,6 +388,14 @@ def test_reject_garbage_in_header_line():
            b"Host: foo\x00bar\r\n\r\n",
            None)
 
+def test_reject_non_vchar_in_path():
+    for bad_char in b"\x00\x20\x7f\xee":
+        message = bytearray(b"HEAD /")
+        message.append(bad_char)
+        message.extend(b" HTTP/1.1\r\nHost: foobar\r\n\r\n")
+        with pytest.raises(LocalProtocolError):
+            tr(READERS[CLIENT, IDLE], message, None)
+
 # https://github.com/python-hyper/h11/issues/57
 def test_allow_some_garbage_in_cookies():
     tr(READERS[CLIENT, IDLE],


### PR DESCRIPTION
This constrains the matching to the printable ASCII characters that
are not the space ' ' character i.e. between '!' (65, 0x21) and '~'
(126, 0x7e). Doing so will mean that a request containing bytes
outside of this range will not match and instead raise an error.

This is based on my understanding of RFC 3986.

I think I've matched the style of the file, although I'm happy for this to be edited however to fit.