### PR TITLE
Make all sentinel values inspectable by IDEs

### DIFF
--- a/h11/_state.py
+++ b/h11/_state.py
@@ -131,6 +131,7 @@ SEND_BODY = make_sentinel("SEND_BODY")
 DONE = make_sentinel("DONE")
 MUST_CLOSE = make_sentinel("MUST_CLOSE")
 CLOSED = make_sentinel("CLOSED")
+ERROR = make_sentinel("ERROR")
 
 # Switch types
 MIGHT_SWITCH_PROTOCOL = make_sentinel("MIGHT_SWITCH_PROTOCOL")

--- a/h11/_state.py
+++ b/h11/_state.py
@@ -114,6 +114,7 @@
 from ._events import *
 from ._util import LocalProtocolError, make_sentinel
 
+# Everything in __all__ gets re-exported as part of the h11 public API.
 __all__ = [
   "CLIENT", "SERVER", "IDLE", "SEND_RESPONSE",
   "SEND_BODY", "DONE", "MUST_CLOSE",

--- a/h11/_state.py
+++ b/h11/_state.py
@@ -116,23 +116,24 @@ from ._util import LocalProtocolError, make_sentinel
 
 __all__ = [
   "CLIENT", "SERVER", "IDLE", "SEND_RESPONSE",
-  "SEND_BODY_DONE", "MUST_CLOSE", "CLOSED",
-  "MIGHT_SWITCH_PROTOCOL", "SWITCHED_PROTOCOL",
-  "ERROR"
+  "SEND_BODY", "DONE", "MUST_CLOSE",
+  "CLOSED", "MIGHT_SWITCH_PROTOCOL",
+  "SWITCHED_PROTOCOL", "ERROR"
 ]
 
 CLIENT = make_sentinel("CLIENT")
-SERVER = make_sentinel("CLIENT")
+SERVER = make_sentinel("SERVER")
 
 # States
 IDLE = make_sentinel("IDLE")
 SEND_RESPONSE = make_sentinel("SEND_RESPONSE")
-SEND_BODY_DONE = make_sentinel("SEND_BODY_DONE")
+SEND_BODY = make_sentinel("SEND_BODY")
+DONE = make_sentinel("DONE")
 MUST_CLOSE = make_sentinel("MUST_CLOSE")
 CLOSED = make_sentinel("CLOSED")
 
 # Switch types
-MIGHT_SWITCH_PROTOCOL = make_sentinel("CLIENT")
+MIGHT_SWITCH_PROTOCOL = make_sentinel("MIGHT_SWITCH_PROTOCOL")
 SWITCHED_PROTOCOL = make_sentinel("SWITCHED_PROTOCOL")
 
 _SWITCH_UPGRADE = make_sentinel("_SWITCH_UPGRADE")

--- a/h11/_state.py
+++ b/h11/_state.py
@@ -114,20 +114,29 @@
 from ._events import *
 from ._util import LocalProtocolError, make_sentinel
 
-# Everything in __all__ gets re-exported as part of the h11 public API.
-__all__ = []
+__all__ = [
+  "CLIENT", "SERVER", "IDLE", "SEND_RESPONSE",
+  "SEND_BODY_DONE", "MUST_CLOSE", "CLOSED",
+  "MIGHT_SWITCH_PROTOCOL", "SWITCHED_PROTOCOL",
+  "ERROR"
+]
 
-# Be careful of trailing whitespace here:
-sentinels = ("CLIENT SERVER "
-             # States
-             "IDLE SEND_RESPONSE SEND_BODY DONE MUST_CLOSE CLOSED "
-             "MIGHT_SWITCH_PROTOCOL SWITCHED_PROTOCOL ERROR "
-             # Switch types
-             "_SWITCH_UPGRADE _SWITCH_CONNECT").split()
-for token in sentinels:
-    globals()[token] = make_sentinel(token)
+CLIENT = make_sentinel("CLIENT")
+SERVER = make_sentinel("CLIENT")
 
-__all__ += [s for s in sentinels if not s.startswith("_")]
+# States
+IDLE = make_sentinel("IDLE")
+SEND_RESPONSE = make_sentinel("SEND_RESPONSE")
+SEND_BODY_DONE = make_sentinel("SEND_BODY_DONE")
+MUST_CLOSE = make_sentinel("MUST_CLOSE")
+CLOSED = make_sentinel("CLOSED")
+
+# Switch types
+MIGHT_SWITCH_PROTOCOL = make_sentinel("CLIENT")
+SWITCHED_PROTOCOL = make_sentinel("SWITCHED_PROTOCOL")
+
+_SWITCH_UPGRADE = make_sentinel("_SWITCH_UPGRADE")
+_SWITCH_CONNECT = make_sentinel("_SWITCH_CONNECT")
 
 EVENT_TRIGGERED_TRANSITIONS = {
     CLIENT: {


### PR DESCRIPTION
PyCharm has difficulty inspecting values that are both dynamically added to `__all__` and created via `globals()[x] = ...`. To the detriment of "only-update-one-place" I think it's valuable to have these values inspectable given how frequently they show up in a users codebase when using this library.