### PR TITLE
Force status codes to be integers, not IntEnums

### DIFF
--- a/h11/_events.py
+++ b/h11/_events.py
@@ -57,6 +57,10 @@ class _EventBundle(object):
             if "status_code" in self.__dict__:
                 if not isinstance(self.status_code, int):
                     raise LocalProtocolError("status code must be integer")
+                # Because IntEnum objects are instances of int, but aren't
+                # duck-compatible (sigh), see gh-72.
+                self.status_code = int(self.status_code)
+
 
         self._validate()
 

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -134,3 +134,16 @@ def test_events():
 
     cc = ConnectionClosed()
     assert repr(cc) == "ConnectionClosed()"
+
+
+def test_intenum_status_code():
+    # https://github.com/python-hyper/h11/issues/72
+    try:
+        from http import HTTPStatus
+    except ImportError:
+        pytest.skip("Only affects Python 3")
+
+    r = Response(status_code=HTTPStatus.OK, headers=[], http_version="1.0")
+    assert r.status_code == HTTPStatus.OK
+    assert type(r.status_code) is not type(HTTPStatus.OK)
+    assert type(r.status_code) is int


### PR DESCRIPTION
IntEnum objects, like http.HTTPStatus objects, are subclasses of int,
but don't behave the same in all circumstances, e.g. string
formatting. Force our status codes to be actual int objects, so that
they'll behave the way we expect.

Fixes gh-72.