### PR TITLE
- Patch for issue #80

### DIFF
--- a/h11/_state.py
+++ b/h11/_state.py
@@ -307,7 +307,10 @@ class ConnectionState(object):
 
     def start_next_cycle(self):
         if self.states != {CLIENT: DONE, SERVER: DONE}:
-            raise LocalProtocolError("not in a reusable state")
+            raise LocalProtocolError(
+                "not in a reusable state."
+                " self.states[CLIENT]={} self.states[SERVER]={}"
+                .format(self.states[CLIENT], self.states[SERVER]))
         # Can't reach DONE/DONE with any of these active, but still, let's be
         # sure.
         assert self.keep_alive


### PR DESCRIPTION
This change adds the current state when raising LocalProtocolError("not in a reusable state"), which significantly simplifies the debugging of the cause of the exception.
