### PR TITLE
Get value from exception to fix pytest 5 compat

### DIFF
--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -44,7 +44,7 @@ def test_event_bundle():
     with pytest.raises(TypeError) as exc:
         T(b=0)
     # make sure we error on the right missing kwarg
-    assert "kwarg a" in str(exc)
+    assert "kwarg a" in str(exc.value)
 
     # _validate is called
     with pytest.raises(ValueError):


### PR DESCRIPTION
Let us see if oneliner is good enough. Issue #86 