### PR TITLE
Preserve header casing

### DIFF
--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -560,13 +560,13 @@ class Connection(object):
             # but the HTTP spec says that if our peer does this then we have
             # to fix it instead of erroring out, so we'll accord the user the
             # same respect).
-            headers = set_comma_header(headers, b"Content-Length", [])
+            set_comma_header(headers, b"Content-Length", [])
             if self.their_http_version is None or self.their_http_version < b"1.1":
                 # Either we never got a valid request and are sending back an
                 # error (their_http_version is None), so we assume the worst;
                 # or else we did get a valid HTTP/1.0 request, so we know that
                 # they don't understand chunked encoding.
-                headers = set_comma_header(headers, b"Transfer-Encoding", [])
+                set_comma_header(headers, b"Transfer-Encoding", [])
                 # This is actually redundant ATM, since currently we
                 # unconditionally disable keep-alive when talking to HTTP/1.0
                 # peers. But let's be defensive just in case we add
@@ -574,13 +574,13 @@ class Connection(object):
                 if self._request_method != b"HEAD":
                     need_close = True
             else:
-                headers = set_comma_header(headers, b"Transfer-Encoding", ["chunked"])
+                set_comma_header(headers, b"Transfer-Encoding", ["chunked"])
 
         if not self._cstate.keep_alive or need_close:
             # Make sure Connection: close is set
             connection = set(get_comma_header(headers, b"Connection"))
             connection.discard(b"keep-alive")
             connection.add(b"close")
-            headers = set_comma_header(headers, b"Connection", sorted(connection))
+            set_comma_header(headers, b"Connection", sorted(connection))
 
         response.headers = headers

--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -534,7 +534,7 @@ class Connection(object):
     def _clean_up_response_headers_for_sending(self, response):
         assert type(response) is Response
 
-        headers = response.headers
+        headers = list(response.headers)
         need_close = False
 
         # HEAD requests need some special handling: they always act like they

--- a/h11/_headers.py
+++ b/h11/_headers.py
@@ -1,4 +1,9 @@
-from collections.abc import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    # Python 2.7 support
+    from collections import Sequence
+
 import re
 
 from ._abnf import field_name, field_value

--- a/h11/_headers.py
+++ b/h11/_headers.py
@@ -73,7 +73,7 @@ class Headers(Sequence):
         self._items = items
 
     def __getitem__(self, item):
-        _, _, value = self._data[item]
+        _, _, value = self._items[item]
         return value
 
     def __len__(self):

--- a/h11/_writers.py
+++ b/h11/_writers.py
@@ -38,14 +38,12 @@ def write_headers(headers, write):
     # "Since the Host field-value is critical information for handling a
     # request, a user agent SHOULD generate Host as the first header field
     # following the request-line." - RFC 7230
-    raw_headers = headers.raw()
-
-    for name, raw_name, value in raw_headers:
-        if name == b"host":
-            write(bytesmod(b"%s: %s\r\n", (raw_name, value)))
-    for name, raw_name, value in raw_headers:
-        if name != b"host":
-            write(bytesmod(b"%s: %s\r\n", (raw_name, value)))
+    for header in headers:
+        if header.name == b"host":
+            write(bytesmod(b"%s: %s\r\n", (header.raw_name, header.value)))
+    for header in headers:
+        if header.name != b"host":
+            write(bytesmod(b"%s: %s\r\n", (header.raw_name, header.value)))
     write(b"\r\n")
 
 

--- a/h11/_writers.py
+++ b/h11/_writers.py
@@ -38,10 +38,12 @@ def write_headers(headers, write):
     # "Since the Host field-value is critical information for handling a
     # request, a user agent SHOULD generate Host as the first header field
     # following the request-line." - RFC 7230
-    for name, value in headers:
+    raw_headers = headers.raw()
+
+    for name, _, value in raw_headers:
         if name == b"host":
             write(bytesmod(b"%s: %s\r\n", (name, value)))
-    for name, value in headers:
+    for name, _, value in raw_headers:
         if name != b"host":
             write(bytesmod(b"%s: %s\r\n", (name, value)))
     write(b"\r\n")

--- a/h11/_writers.py
+++ b/h11/_writers.py
@@ -40,12 +40,12 @@ def write_headers(headers, write):
     # following the request-line." - RFC 7230
     raw_headers = headers.raw()
 
-    for name, _, value in raw_headers:
+    for name, raw_name, value in raw_headers:
         if name == b"host":
-            write(bytesmod(b"%s: %s\r\n", (name, value)))
-    for name, _, value in raw_headers:
+            write(bytesmod(b"%s: %s\r\n", (raw_name, value)))
+    for name, raw_name, value in raw_headers:
         if name != b"host":
-            write(bytesmod(b"%s: %s\r\n", (name, value)))
+            write(bytesmod(b"%s: %s\r\n", (raw_name, value)))
     write(b"\r\n")
 
 

--- a/h11/tests/test_connection.py
+++ b/h11/tests/test_connection.py
@@ -96,7 +96,7 @@ def test_Connection_basics_and_content_length():
         ),
     )
     assert data == (
-        b"GET / HTTP/1.1\r\n" b"host: example.com\r\n" b"content-length: 10\r\n\r\n"
+        b"GET / HTTP/1.1\r\n" b"Host: example.com\r\n" b"Content-Length: 10\r\n\r\n"
     )
 
     for conn in p.conns:
@@ -113,7 +113,7 @@ def test_Connection_basics_and_content_length():
     assert data == b"HTTP/1.1 100 \r\n\r\n"
 
     data = p.send(SERVER, Response(status_code=200, headers=[("Content-Length", "11")]))
-    assert data == b"HTTP/1.1 200 \r\ncontent-length: 11\r\n\r\n"
+    assert data == b"HTTP/1.1 200 \r\nContent-Length: 11\r\n\r\n"
 
     for conn in p.conns:
         assert conn.states == {CLIENT: SEND_BODY, SERVER: SEND_BODY}
@@ -243,7 +243,7 @@ def test_server_talking_to_http10_client():
     # We automatically Connection: close back at them
     assert (
         c.send(Response(status_code=200, headers=[]))
-        == b"HTTP/1.1 200 \r\nconnection: close\r\n\r\n"
+        == b"HTTP/1.1 200 \r\nConnection: close\r\n\r\n"
     )
 
     assert c.send(Data(data=b"12345")) == b"12345"
@@ -303,7 +303,7 @@ def test_automatic_transfer_encoding_in_response():
         receive_and_get(c, b"GET / HTTP/1.0\r\n\r\n")
         assert (
             c.send(Response(status_code=200, headers=user_headers))
-            == b"HTTP/1.1 200 \r\nconnection: close\r\n\r\n"
+            == b"HTTP/1.1 200 \r\nConnection: close\r\n\r\n"
         )
         assert c.send(Data(data=b"12345")) == b"12345"
 
@@ -876,7 +876,7 @@ def test_errors():
         if role is SERVER:
             assert (
                 c.send(Response(status_code=400, headers=[]))
-                == b"HTTP/1.1 400 \r\nconnection: close\r\n\r\n"
+                == b"HTTP/1.1 400 \r\nConnection: close\r\n\r\n"
             )
 
     # After an error sending, you can no longer send
@@ -988,14 +988,14 @@ def test_HEAD_framing_headers():
         c = setup(method, b"1.1")
         assert (
             c.send(Response(status_code=200, headers=[])) == b"HTTP/1.1 200 \r\n"
-            b"transfer-encoding: chunked\r\n\r\n"
+            b"Transfer-Encoding: chunked\r\n\r\n"
         )
 
         # No Content-Length, HTTP/1.0 peer, frame with connection: close
         c = setup(method, b"1.0")
         assert (
             c.send(Response(status_code=200, headers=[])) == b"HTTP/1.1 200 \r\n"
-            b"connection: close\r\n\r\n"
+            b"Connection: close\r\n\r\n"
         )
 
         # Content-Length + Transfer-Encoding, TE wins
@@ -1011,7 +1011,7 @@ def test_HEAD_framing_headers():
                 )
             )
             == b"HTTP/1.1 200 \r\n"
-            b"transfer-encoding: chunked\r\n\r\n"
+            b"Transfer-Encoding: chunked\r\n\r\n"
         )
 
 

--- a/h11/tests/test_headers.py
+++ b/h11/tests/test_headers.py
@@ -83,7 +83,7 @@ def test_get_set_comma_header():
 
     assert get_comma_header(headers, b"connection") == [b"close", b"foo", b"bar"]
 
-    set_comma_header(headers, b"newthing", ["a", "b"])
+    headers = set_comma_header(headers, b"newthing", ["a", "b"])
 
     with pytest.raises(LocalProtocolError):
         set_comma_header(headers, b"newthing", ["  a", "b"])
@@ -96,7 +96,7 @@ def test_get_set_comma_header():
         (b"newthing", b"b"),
     ]
 
-    set_comma_header(headers, b"whatever", ["different thing"])
+    headers = set_comma_header(headers, b"whatever", ["different thing"])
 
     assert headers == [
         (b"connection", b"close"),

--- a/h11/tests/test_headers.py
+++ b/h11/tests/test_headers.py
@@ -83,7 +83,7 @@ def test_get_set_comma_header():
 
     assert get_comma_header(headers, b"connection") == [b"close", b"foo", b"bar"]
 
-    headers = set_comma_header(headers, b"newthing", ["a", "b"])
+    set_comma_header(headers, b"newthing", ["a", "b"])
 
     with pytest.raises(LocalProtocolError):
         set_comma_header(headers, b"newthing", ["  a", "b"])
@@ -96,7 +96,7 @@ def test_get_set_comma_header():
         (b"newthing", b"b"),
     ]
 
-    headers = set_comma_header(headers, b"whatever", ["different thing"])
+    set_comma_header(headers, b"whatever", ["different thing"])
 
     assert headers == [
         (b"connection", b"close"),

--- a/h11/tests/test_io.py
+++ b/h11/tests/test_io.py
@@ -121,7 +121,7 @@ def test_writers_unusual():
         normalize_and_validate([("foo", "bar"), ("baz", "quux")]),
         b"foo: bar\r\nbaz: quux\r\n\r\n",
     )
-    tw(write_headers, [], b"\r\n")
+    tw(write_headers, normalize_and_validate([]), b"\r\n")
 
     # We understand HTTP/1.0, but we don't speak it
     with pytest.raises(LocalProtocolError):

--- a/h11/tests/test_io.py
+++ b/h11/tests/test_io.py
@@ -121,7 +121,7 @@ def test_writers_unusual():
         normalize_and_validate([("foo", "bar"), ("baz", "quux")]),
         b"foo: bar\r\nbaz: quux\r\n\r\n",
     )
-    tw(write_headers, normalize_and_validate([]), b"\r\n")
+    tw(write_headers, [], b"\r\n")
 
     # We understand HTTP/1.0, but we don't speak it
     with pytest.raises(LocalProtocolError):

--- a/h11/tests/test_io.py
+++ b/h11/tests/test_io.py
@@ -31,12 +31,12 @@ SIMPLE_CASES = [
             target="/a",
             headers=[("Host", "foo"), ("Connection", "close")],
         ),
-        b"GET /a HTTP/1.1\r\nhost: foo\r\nconnection: close\r\n\r\n",
+        b"GET /a HTTP/1.1\r\nHost: foo\r\nConnection: close\r\n\r\n",
     ),
     (
         (SERVER, SEND_RESPONSE),
         Response(status_code=200, headers=[("Connection", "close")], reason=b"OK"),
-        b"HTTP/1.1 200 OK\r\nconnection: close\r\n\r\n",
+        b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n",
     ),
     (
         (SERVER, SEND_RESPONSE),
@@ -48,7 +48,7 @@ SIMPLE_CASES = [
         InformationalResponse(
             status_code=101, headers=[("Upgrade", "websocket")], reason=b"Upgrade"
         ),
-        b"HTTP/1.1 101 Upgrade\r\nupgrade: websocket\r\n\r\n",
+        b"HTTP/1.1 101 Upgrade\r\nUpgrade: websocket\r\n\r\n",
     ),
     (
         (SERVER, SEND_RESPONSE),
@@ -435,7 +435,7 @@ def test_ChunkedWriter():
 
     assert (
         dowrite(w, EndOfMessage(headers=[("Etag", "asdf"), ("a", "b")]))
-        == b"0\r\netag: asdf\r\na: b\r\n\r\n"
+        == b"0\r\nEtag: asdf\r\na: b\r\n\r\n"
     )
 
 
@@ -503,5 +503,5 @@ def test_host_comes_first():
     tw(
         write_headers,
         normalize_and_validate([("foo", "bar"), ("Host", "example.com")]),
-        b"host: example.com\r\nfoo: bar\r\n\r\n",
+        b"Host: example.com\r\nfoo: bar\r\n\r\n",
     )


### PR DESCRIPTION
A proposal for preserving header casing information in both directions, while still exposing lower-case only to users by default, and keeping careful type separation. 

Essentially a take on @Lukasa's comment here https://github.com/python-hyper/h11/issues/31#issuecomment-281013856 and @njsmith's follow up...

> write a data structure that is basically a tuple, but allows you to access headers either case sensitively or case insensitively (where case insensitively is the default)

> Here's a really simple (maybe too simple) idea to throw into the mix: use tuples of (header, header_with_original_casing, value)

Here's how it looks to the end-user...

* `h11` now preserves header casing on sending headers.
* `.headers` becomes a `Sequence` type, rather than a raw list. Iterating over the sequence continues to return `(<lowercased-name>, <value>)` pairs.
* `.headers.raw()` is available for usages such as console or debug output that require original casing information, and returns a list of `(<lowercased-name>, <raw-name>, <value>)` three-tuples.

I've addressed this commit-by-commit, which should help make the approach I've taken here clear...

1. Headers becomes a `Sequence` type, rather than a raw mutable list, but continues to store exactly the same information.
2. Store raw casing information in the `Headers` type, but don't use it anywhere.
3. Use title casing anywhere we're using `get_comma_header`, `set_comma_header`. Both functions continue to be case insensitive in their effects, but it will matter in the `set_comma_header` case because it'll give us nice header casing on the over-the-wire bytes. Switching both over within the codebase for consistency.
4. Switch the writer to use the raw header casing.

Strictly speaking there *is* an API change here, in that `.headers` on events are now sequences, rather than plain lists. Any user code that is doing grungy stuff by mutating that data-structure in-place, wouldn't function after this. But that's a bit of a hacky broken thing to be doing anyway, so a version bump that tightened up the API spec into "`.headers` is an immutable sequence" seems reasonable enough right?

Anyway's putting this out there, so we've got something to discuss. 🤔

Thanks so much for maintaining such a fantastically careful & thoroughly designed library. It's a joy to work with. ✨