### PR TITLE
Added ability to use LF, not only CRLF delimiter for response Headers and Body

### DIFF
--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -425,7 +425,6 @@ class Connection(object):
             event = self._extract_next_receive_event()
             if event not in [NEED_DATA, PAUSED]:
                 self._process_event(self.their_role, event)
-                self._receive_buffer.compress()
             if event is NEED_DATA:
                 if len(self._receive_buffer) > self._max_incomplete_event_size:
                     # 431 is "Request header fields too large" which is pretty

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -21,6 +21,7 @@ import re
 from ._abnf import chunk_header, header_field, request_line, status_line
 from ._events import *
 from ._state import *
+from ._receivebuffer import line_delimiter_regex
 from ._util import LocalProtocolError, RemoteProtocolError, validate
 
 __all__ = ["READERS"]
@@ -153,7 +154,7 @@ class ChunkedReader(object):
         assert self._bytes_to_discard == 0
         if self._bytes_in_chunk == 0:
             # We need to refill our chunk count
-            chunk_header = buf.maybe_extract_until_next(b"\r?\n")
+            chunk_header = buf.maybe_extract_until_next(line_delimiter_regex, 2)
             if chunk_header is None:
                 return None
             matches = validate(

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -20,7 +20,6 @@ import re
 
 from ._abnf import chunk_header, header_field, request_line, status_line
 from ._events import *
-from ._receivebuffer import line_delimiter_regex
 from ._state import *
 from ._util import LocalProtocolError, RemoteProtocolError, validate
 

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -153,7 +153,7 @@ class ChunkedReader(object):
         assert self._bytes_to_discard == 0
         if self._bytes_in_chunk == 0:
             # We need to refill our chunk count
-            chunk_header = buf.maybe_extract_until_next(b"\r\n")
+            chunk_header = buf.maybe_extract_until_delimiter(b"\r?\n")
             if chunk_header is None:
                 return None
             matches = validate(

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -30,7 +30,6 @@ header_field_re = re.compile(header_field.encode("ascii"))
 # Remember that this has to run in O(n) time -- so e.g. the bytearray cast is
 # critical.
 obs_fold_re = re.compile(br"[ \t]+")
-strict_line_delimiter_regex = re.compile(b"\r\n", re.MULTILINE)
 
 
 def _obsolete_line_fold(lines):
@@ -154,7 +153,7 @@ class ChunkedReader(object):
         assert self._bytes_to_discard == 0
         if self._bytes_in_chunk == 0:
             # We need to refill our chunk count
-            chunk_header = buf.maybe_extract_until_next(strict_line_delimiter_regex, 2)
+            chunk_header = buf.maybe_extract_next_line()
             if chunk_header is None:
                 return None
             matches = validate(

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -31,6 +31,7 @@ header_field_re = re.compile(header_field.encode("ascii"))
 # Remember that this has to run in O(n) time -- so e.g. the bytearray cast is
 # critical.
 obs_fold_re = re.compile(br"[ \t]+")
+strict_line_delimiter_regex = re.compile(b"\r\n", re.MULTILINE)
 
 
 def _obsolete_line_fold(lines):
@@ -154,7 +155,7 @@ class ChunkedReader(object):
         assert self._bytes_to_discard == 0
         if self._bytes_in_chunk == 0:
             # We need to refill our chunk count
-            chunk_header = buf.maybe_extract_until_next(line_delimiter_regex, 2)
+            chunk_header = buf.maybe_extract_until_next(strict_line_delimiter_regex, 2)
             if chunk_header is None:
                 return None
             matches = validate(

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -153,7 +153,7 @@ class ChunkedReader(object):
         assert self._bytes_to_discard == 0
         if self._bytes_in_chunk == 0:
             # We need to refill our chunk count
-            chunk_header = buf.maybe_extract_until_delimiter(b"\r?\n")
+            chunk_header = buf.maybe_extract_until_next(b"\r?\n")
             if chunk_header is None:
                 return None
             matches = validate(

--- a/h11/_readers.py
+++ b/h11/_readers.py
@@ -20,8 +20,8 @@ import re
 
 from ._abnf import chunk_header, header_field, request_line, status_line
 from ._events import *
-from ._state import *
 from ._receivebuffer import line_delimiter_regex
+from ._state import *
 from ._util import LocalProtocolError, RemoteProtocolError, validate
 
 __all__ = ["READERS"]

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -5,7 +5,8 @@ __all__ = ["ReceiveBuffer"]
 
 
 # Operations we want to support:
-# - find next \r\n or \r\n\r\n, or wait until there is one
+# - find next \r\n or \r\n\r\n (\n or \n\n are also acceptable),
+#   or wait until there is one
 # - read at-most-N bytes
 # Goals:
 # - on average, do this fast
@@ -40,7 +41,7 @@ __all__ = ["ReceiveBuffer"]
 # processed a whole event, which could in theory be slightly more efficient
 # than the internal bytearray support.)
 
-body_and_headers_delimiter_regex = re.compile(b"\n\r?\n", re.MULTILINE)
+blank_line_delimiter_regex = re.compile(b"\n\r?\n", re.MULTILINE)
 line_delimiter_regex = re.compile(b"\r?\n", re.MULTILINE)
 
 
@@ -50,7 +51,8 @@ class ReceiveBuffer(object):
         # These are both absolute offsets into self._data:
         self._start = 0
         self._looked_at = 0
-        self._looked_for_regex = body_and_headers_delimiter_regex
+
+        self._looked_for_regex = blank_line_delimiter_regex
 
     def __bool__(self):
         return bool(len(self))
@@ -129,7 +131,7 @@ class ReceiveBuffer(object):
             self._start += len(start_chunk)
             return []
         else:
-            data = self.maybe_extract_until_next(body_and_headers_delimiter_regex, 3)
+            data = self.maybe_extract_until_next(blank_line_delimiter_regex, 3)
             if data is None:
                 return None
 

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -127,7 +127,11 @@ class ReceiveBuffer(object):
         # Truncate the buffer and return it.
         idx = match.span(0)[-1]
         out = self._extract(idx)
-        lines = [line.rstrip(b"\r") for line in out.split(b"\n")]
+        lines = out.split(b"\n")
+
+        for line in lines:
+            if line.endswith(b"\r"):
+                del line[-1]
 
         assert lines[-2] == lines[-1] == b""
 

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -42,7 +42,10 @@ __all__ = ["ReceiveBuffer"]
 # than the internal bytearray support.)
 
 blank_line_delimiter_regex = re.compile(b"\n\r?\n", re.MULTILINE)
-line_delimiter_regex = re.compile(b"\r?\n", re.MULTILINE)
+
+
+def rstrip_line(line):
+    return line.rstrip(b"\r")
 
 
 class ReceiveBuffer(object):
@@ -126,6 +129,6 @@ class ReceiveBuffer(object):
             if data is None:
                 return None
 
-            lines = line_delimiter_regex.split(data.rstrip(b"\r\n"))
+            lines = list(map(rstrip_line, data.rstrip(b"\r\n").split(b"\n")))
 
             return lines

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -95,7 +95,7 @@ class ReceiveBuffer(object):
         else:
             looked_at = self._start
             self._looked_for = needle
-            # re.compile operation is more expensive than just byte compare
+            # Check if default delimiter to avoid expensive re.compile
             if needle == default_delimiter:
                 self._looked_for_regex = delimiter_regex
             else:

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -135,7 +135,9 @@ class ReceiveBuffer(object):
             if data is None:
                 return None
 
-            real_lines_delimiter = self._get_fields_delimiter(data, line_delimiter_regex)
+            real_lines_delimiter = self._get_fields_delimiter(
+                data, line_delimiter_regex
+            )
             lines = data.rstrip(b"\r\n").split(real_lines_delimiter)
 
             return lines

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -86,14 +86,16 @@ class ReceiveBuffer(object):
         Extract the first line, if it is completed in the buffer.
         """
         # Only search in buffer space that we've not already looked at.
-        partial_buffer = self._data[self._next_line_search :]
-        partial_idx = partial_buffer.find(b"\n")
+        search_start_index = max(0, self._next_line_search - 1)
+        partial_buffer = self._data[search_start_index:]
+        partial_idx = partial_buffer.find(b"\r\n")
         if partial_idx == -1:
             self._next_line_search = len(self._data)
             return None
 
         # Truncate the buffer and return it.
-        idx = self._next_line_search + partial_idx + 1
+        # + 2 is to compensate len(b"\r\n")
+        idx = search_start_index + partial_idx + 2
         out = self._data[:idx]
         self._data[:idx] = b""
         self._next_line_search = 0

--- a/h11/tests/test_io.py
+++ b/h11/tests/test_io.py
@@ -215,6 +215,43 @@ def test_readers_unusual():
         ),
     )
 
+    # Tolerate headers line endings (\r\n and \n)
+    #    \n\r\b between headers and body
+    tr(
+        READERS[SERVER, SEND_RESPONSE],
+        b"HTTP/1.1 200 OK\r\nSomeHeader: val\n\r\n",
+        Response(
+            status_code=200,
+            headers=[("SomeHeader", "val")],
+            http_version="1.1",
+            reason="OK",
+        ),
+    )
+
+    #   delimited only with \n
+    tr(
+        READERS[SERVER, SEND_RESPONSE],
+        b"HTTP/1.1 200 OK\nSomeHeader1: val1\nSomeHeader2: val2\n\n",
+        Response(
+            status_code=200,
+            headers=[("SomeHeader1", "val1"), ("SomeHeader2", "val2")],
+            http_version="1.1",
+            reason="OK",
+        ),
+    )
+
+    #   mixed \r\n and \n
+    tr(
+        READERS[SERVER, SEND_RESPONSE],
+        b"HTTP/1.1 200 OK\r\nSomeHeader1: val1\nSomeHeader2: val2\n\r\n",
+        Response(
+            status_code=200,
+            headers=[("SomeHeader1", "val1"), ("SomeHeader2", "val2")],
+            http_version="1.1",
+            reason="OK",
+        ),
+    )
+
     # obsolete line folding
     tr(
         READERS[CLIENT, IDLE],

--- a/h11/tests/test_receivebuffer.py
+++ b/h11/tests/test_receivebuffer.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from .._receivebuffer import ReceiveBuffer
@@ -37,23 +39,23 @@ def test_receivebuffer():
 
     b += b"12345a6789aa"
 
-    assert b.maybe_extract_until_next(b"a") == b"12345a"
+    assert b.maybe_extract_until_next(re.compile(b"a"), 1) == b"12345a"
     assert bytes(b) == b"6789aa"
 
-    assert b.maybe_extract_until_next(b"aaa") is None
+    assert b.maybe_extract_until_next(re.compile(b"aaa"), 3) is None
     assert bytes(b) == b"6789aa"
 
     b += b"a12"
-    assert b.maybe_extract_until_next(b"aaa") == b"6789aaa"
+    assert b.maybe_extract_until_next(re.compile(b"aaa"), 3) == b"6789aaa"
     assert bytes(b) == b"12"
 
     # check repeated searches for the same needle, triggering the
     # pickup-where-we-left-off logic
     b += b"345"
-    assert b.maybe_extract_until_next(b"aaa") is None
+    assert b.maybe_extract_until_next(re.compile(b"aaa"), 3) is None
 
     b += b"6789aaa123"
-    assert b.maybe_extract_until_next(b"aaa") == b"123456789aaa"
+    assert b.maybe_extract_until_next(re.compile(b"aaa"), 3) == b"123456789aaa"
     assert bytes(b) == b"123"
 
     ################################################################

--- a/h11/tests/test_receivebuffer.py
+++ b/h11/tests/test_receivebuffer.py
@@ -85,14 +85,37 @@ def test_receivebuffer():
 @pytest.mark.parametrize(
     "data",
     [
-        (
-            b"HTTP/1.1 200 OK\r\n",
-            b"Content-type: text/plain\r\n",
-            b"\r\n",
-            b"Some body",
+        pytest.param(
+            (
+                b"HTTP/1.1 200 OK\r\n",
+                b"Content-type: text/plain\r\n",
+                b"\r\n",
+                b"Some body",
+            ),
+            id="with_crlf_delimiter",
         ),
-        (b"HTTP/1.1 200 OK\n", b"Content-type: text/plain\n", b"\n", b"Some body"),
-        (b"HTTP/1.1 200 OK\r\n", b"Content-type: text/plain\n", b"\n", b"Some body"),
+        pytest.param(
+            (b"HTTP/1.1 200 OK\n", b"Content-type: text/plain\n", b"\n", b"Some body"),
+            id="with_lf_only_delimiter",
+        ),
+        pytest.param(
+            (
+                b"HTTP/1.1 200 OK\r\n",
+                b"Content-type: text/plain\n",
+                b"\n",
+                b"Some body",
+            ),
+            id="with_double_lf_before_body",
+        ),
+        pytest.param(
+            (
+                b"HTTP/1.1 200 OK\r\n",
+                b"Content-type: text/plain\r\n",
+                b"\n",
+                b"Some body",
+            ),
+            id="with_mixed_crlf",
+        ),
     ],
 )
 def test_receivebuffer_for_invalid_delimiter(data):

--- a/h11/tests/test_receivebuffer.py
+++ b/h11/tests/test_receivebuffer.py
@@ -32,28 +32,28 @@ def test_receivebuffer():
     assert not b
 
     ################################################################
-    # maybe_extract_until_delimiter
+    # maybe_extract_until_next
     ################################################################
 
     b += b"12345a6789aa"
 
-    assert b.maybe_extract_until_delimiter(b"a") == b"12345a"
+    assert b.maybe_extract_until_next(b"a") == b"12345a"
     assert bytes(b) == b"6789aa"
 
-    assert b.maybe_extract_until_delimiter(b"aaa") is None
+    assert b.maybe_extract_until_next(b"aaa") is None
     assert bytes(b) == b"6789aa"
 
     b += b"a12"
-    assert b.maybe_extract_until_delimiter(b"aaa") == b"6789aaa"
+    assert b.maybe_extract_until_next(b"aaa") == b"6789aaa"
     assert bytes(b) == b"12"
 
     # check repeated searches for the same needle, triggering the
     # pickup-where-we-left-off logic
     b += b"345"
-    assert b.maybe_extract_until_delimiter(b"aaa") is None
+    assert b.maybe_extract_until_next(b"aaa") is None
 
     b += b"6789aaa123"
-    assert b.maybe_extract_until_delimiter(b"aaa") == b"123456789aaa"
+    assert b.maybe_extract_until_next(b"aaa") == b"123456789aaa"
     assert bytes(b) == b"123"
 
     ################################################################

--- a/h11/tests/test_receivebuffer.py
+++ b/h11/tests/test_receivebuffer.py
@@ -35,26 +35,28 @@ def test_receivebuffer():
     # maybe_extract_until_next
     ################################################################
 
-    b += b"12345\n6789\r\n"
+    b += b"123\n456\r\n789\r\n"
 
-    assert b.maybe_extract_next_line() == b"12345\n"
-    assert bytes(b) == b"6789\r\n"
+    assert b.maybe_extract_next_line() == b"123\n456\r\n"
+    assert bytes(b) == b"789\r\n"
 
-    assert b.maybe_extract_next_line() == b"6789\r\n"
+    assert b.maybe_extract_next_line() == b"789\r\n"
     assert bytes(b) == b""
 
     b += b"12\r"
     assert b.maybe_extract_next_line() is None
     assert bytes(b) == b"12\r"
 
-    # check repeated searches for the same needle, triggering the
-    # pickup-where-we-left-off logic
     b += b"345\n\r"
-    assert b.maybe_extract_next_line() == b"12\r345\n"
-    assert bytes(b) == b"\r"
+    assert b.maybe_extract_next_line() is None
+    assert bytes(b) == b"12\r345\n\r"
 
-    b += b"6789aaa123\n"
-    assert b.maybe_extract_next_line() == b"\r6789aaa123\n"
+    # here we stopped at the middle of b"\r\n" delimiter
+
+    b += b"\n6789aaa123\r\n"
+    assert b.maybe_extract_next_line() == b"12\r345\n\r\n"
+    assert b.maybe_extract_next_line() == b"6789aaa123\r\n"
+    assert b.maybe_extract_next_line() is None
     assert bytes(b) == b""
 
     ################################################################

--- a/h11/tests/test_receivebuffer.py
+++ b/h11/tests/test_receivebuffer.py
@@ -89,32 +89,31 @@ def test_receivebuffer():
             (
                 b"HTTP/1.1 200 OK\r\n",
                 b"Content-type: text/plain\r\n",
+                b"Connection: close\r\n",
                 b"\r\n",
                 b"Some body",
             ),
             id="with_crlf_delimiter",
         ),
         pytest.param(
-            (b"HTTP/1.1 200 OK\n", b"Content-type: text/plain\n", b"\n", b"Some body"),
+            (
+                b"HTTP/1.1 200 OK\n",
+                b"Content-type: text/plain\n",
+                b"Connection: close\n",
+                b"\n",
+                b"Some body",
+            ),
             id="with_lf_only_delimiter",
         ),
         pytest.param(
             (
-                b"HTTP/1.1 200 OK\r\n",
-                b"Content-type: text/plain\n",
-                b"\n",
-                b"Some body",
-            ),
-            id="with_double_lf_before_body",
-        ),
-        pytest.param(
-            (
-                b"HTTP/1.1 200 OK\r\n",
+                b"HTTP/1.1 200 OK\n",
                 b"Content-type: text/plain\r\n",
+                b"Connection: close\n",
                 b"\n",
                 b"Some body",
             ),
-            id="with_mixed_crlf",
+            id="with_mixed_crlf_and_lf",
         ),
     ],
 )
@@ -126,5 +125,9 @@ def test_receivebuffer_for_invalid_delimiter(data):
 
     lines = b.maybe_extract_lines()
 
-    assert lines == [b"HTTP/1.1 200 OK", b"Content-type: text/plain"]
+    assert lines == [
+        b"HTTP/1.1 200 OK",
+        b"Content-type: text/plain",
+        b"Connection: close",
+    ]
     assert bytes(b) == b"Some body"

--- a/newsfragments/7.feature.rst
+++ b/newsfragments/7.feature.rst
@@ -1,0 +1,3 @@
+Added support for servers with broken line endings.
+
+After this change `h11` accepts both `\r\n` and `\n` as a headers delimiter

--- a/newsfragments/7.feature.rst
+++ b/newsfragments/7.feature.rst
@@ -1,3 +1,3 @@
 Added support for servers with broken line endings.
 
-After this change `h11` accepts both `\r\n` and `\n` as a headers delimiter
+After this change h11 accepts both ``\r\n`` and ``\n`` as a headers delimiter.


### PR DESCRIPTION
Hello,

I want to submit a PR which closes https://github.com/python-hyper/h11/issues/7

#### Why the changes are required
According to [this](https://github.com/python-hyper/h11/issues/7#issuecomment-722464047) comment in the issue, there are problems with some old servers, which are not totally fit `HTTP/1.1` RFC. The original issue in `httpx` (https://github.com/encode/httpx/issues/1378) describes the situation, where some embedded system developers have to deal with a non-standard server

#### What has been done?
I tried to reimplement the function, which extracts headers for response, using regex

#### What hasn't done yet
~Performance testing, fuzzing~

### _(updates)_ How `maybe_extract_lines` works for now?
1. first of all it extracts part of `self._data` buffer until the `"\n\r?\n"`, which gives `data`
1. then it determines the line delimiter in `data` using `"\r?\n"` regex, which gives `delimiter`
1. then split lines using bytearray's `.split(delimiter)` (it much faster than `regex.split(data)`)

#### With fix
```
6099.7 requests/sec
6172.2 requests/sec
6094.7 requests/sec
6202.1 requests/sec
6303.3 requests/sec
6358.0 requests/sec
6372.2 requests/sec
```

#### Without fix (522b004)
```
6065.5 requests/sec
6211.9 requests/sec
6211.1 requests/sec
6131.1 requests/sec
6333.1 requests/sec
6103.8 requests/sec
6260.0 requests/sec
```