### PR TITLE
Drop support for Python 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - 2.7
         - 3.6
         - 3.7
         - 3.8
-        - pypy2
         - pypy3
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,10 @@ other hand, the following are all very welcome:
   tox
   ```
 
-  But note that: (1) this will print slightly misleading coverage
+  But note that: (1) this might print slightly misleading coverage
   statistics, because it only shows coverage for individual python
-  versions, and there are some lines that are only executed on python
-  2 or only executed on python 3, and (2) the full test suite will
+  versions, and there might be some lines that are only executed on some
+  python versions or implementations, and (2) the full test suite will
   automatically get run when you submit a pull request, so you don't
   need to worry too much about tracking down a version of cpython 3.3
   or whatever just to run the tests.

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,8 @@ library.
 It has a test suite with 100.0% coverage for both statements and
 branches.
 
-Currently it supports Python 3 (testing on 3.5-3.8), Python 2.7, and PyPy.
+Currently it supports Python 3 (testing on 3.5-3.8) and PyPy 3.
+The last Python 2-compatible version was h11 0.11.x.
 (Originally it had a Cython wrapper for `http-parser
 <https://github.com/nodejs/http-parser>`_ and a beautiful nested state
 machine implemented with ``yield from`` to postprocess the output. But

--- a/bench/asv.conf.json
+++ b/bench/asv.conf.json
@@ -36,7 +36,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7", "3.5", "pypy"],
+    "pythons": ["3.8", "pypy3"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,9 @@ whatever. But h11 makes it much easier to implement something like
 Vital statistics
 ----------------
 
-* Requirements: Python 2.7 or Python 3.5+ (PyPy works great)
+* Requirements: Python 3.5+ (PyPy works great)
+
+  The last Python 2-compatible version was h11 0.11.x.
 
 * Install: ``pip install h11``
 

--- a/fuzz/afl-server.py
+++ b/fuzz/afl-server.py
@@ -9,11 +9,6 @@ import afl
 
 import h11
 
-if sys.version_info[0] >= 3:
-    in_file = sys.stdin.detach()
-else:
-    in_file = sys.stdin
-
 
 def process_all(c):
     while True:
@@ -26,7 +21,7 @@ def process_all(c):
 
 afl.init()
 
-data = in_file.read()
+data = sys.stdin.detach().read()
 
 # one big chunk
 server1 = h11.Connection(h11.SERVER)

--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -109,7 +109,7 @@ def _body_framing(request_method, event):
 ################################################################
 
 
-class Connection(object):
+class Connection:
     """An object encapsulating the state of an HTTP connection.
 
     Args:

--- a/h11/_events.py
+++ b/h11/_events.py
@@ -24,7 +24,7 @@ __all__ = [
 request_target_re = re.compile(request_target.encode("ascii"))
 
 
-class _EventBundle(object):
+class _EventBundle:
     _fields = []
     _defaults = {}
 
@@ -84,9 +84,6 @@ class _EventBundle(object):
     # Useful for tests
     def __eq__(self, other):
         return self.__class__ == other.__class__ and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     # This is an unhashable type.
     __hash__ = None

--- a/h11/_headers.py
+++ b/h11/_headers.py
@@ -132,7 +132,7 @@ def normalize_and_validate(headers, _parsed=False):
         raw_name = name
         name = name.lower()
         if name == b"content-length":
-            lengths = set(length.strip() for length in value.split(b","))
+            lengths = {length.strip() for length in value.split(b",")}
             if len(lengths) != 1:
                 raise LocalProtocolError("conflicting Content-Length headers")
             value = lengths.pop()

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -1,5 +1,3 @@
-import sys
-
 __all__ = ["ReceiveBuffer"]
 
 
@@ -38,7 +36,7 @@ __all__ = ["ReceiveBuffer"]
 # slightly clever thing where we delay calling compress() until we've
 # processed a whole event, which could in theory be slightly more efficient
 # than the internal bytearray support.)
-class ReceiveBuffer(object):
+class ReceiveBuffer:
     def __init__(self):
         self._data = bytearray()
         # These are both absolute offsets into self._data:
@@ -52,10 +50,6 @@ class ReceiveBuffer(object):
     # for @property unprocessed_data
     def __bytes__(self):
         return bytes(self._data[self._start :])
-
-    if sys.version_info[0] < 3:  # version specific: Python 2
-        __str__ = __bytes__
-        __nonzero__ = __bool__
 
     def __len__(self):
         return len(self._data) - self._start

--- a/h11/_state.py
+++ b/h11/_state.py
@@ -197,7 +197,7 @@ STATE_TRIGGERED_TRANSITIONS = {
 }
 
 
-class ConnectionState(object):
+class ConnectionState:
     def __init__(self):
         # Extra bits of state that don't quite fit into the state model.
 

--- a/h11/_util.py
+++ b/h11/_util.py
@@ -1,6 +1,3 @@
-import re
-import sys
-
 __all__ = [
     "ProtocolError",
     "LocalProtocolError",
@@ -74,34 +71,17 @@ class LocalProtocolError(ProtocolError):
         # (exc_info[0]) separately from the exception object (exc_info[1]),
         # and we only modified the latter. So we really do need to re-raise
         # the new type explicitly.
-        if sys.version_info[0] >= 3:
-            # On py3, the traceback is part of the exception object, so our
-            # in-place modification preserved it and we can just re-raise:
-            raise self
-        else:
-            # On py2, preserving the traceback requires 3-argument
-            # raise... but on py3 this is a syntax error, so we have to hide
-            # it inside an exec
-            exec("raise RemoteProtocolError, self, sys.exc_info()[2]")
+        # On py3, the traceback is part of the exception object, so our
+        # in-place modification preserved it and we can just re-raise:
+        raise self
 
 
 class RemoteProtocolError(ProtocolError):
     pass
 
 
-try:
-    _fullmatch = type(re.compile("")).fullmatch
-except AttributeError:
-
-    def _fullmatch(regex, data):  # version specific: Python < 3.4
-        match = regex.match(data)
-        if match and match.end() != len(data):
-            match = None
-        return match
-
-
 def validate(regex, data, msg="malformed data", *format_args):
-    match = _fullmatch(regex, data)
+    match = regex.fullmatch(data)
     if not match:
         if format_args:
             msg = msg.format(*format_args)

--- a/h11/tests/test_against_stdlib_http.py
+++ b/h11/tests/test_against_stdlib_http.py
@@ -1,25 +1,13 @@
 import json
 import os.path
 import socket
+import socketserver
 import threading
 from contextlib import closing, contextmanager
+from http.server import SimpleHTTPRequestHandler
+from urllib.request import urlopen
 
 import h11
-
-try:
-    from urllib.request import urlopen
-except ImportError:  # version specific: Python 2
-    from urllib2 import urlopen
-
-try:
-    import socketserver
-except ImportError:  # version specific: Python 2
-    import SocketServer as socketserver
-
-try:
-    from http.server import SimpleHTTPRequestHandler
-except ImportError:  # version specific: Python 2
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
 
 
 @contextmanager

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 import pytest
 
 from .. import _events
@@ -154,10 +156,6 @@ def test_events():
 
 def test_intenum_status_code():
     # https://github.com/python-hyper/h11/issues/72
-    try:
-        from http import HTTPStatus
-    except ImportError:
-        pytest.skip("Only affects Python 3")
 
     r = Response(status_code=HTTPStatus.OK, headers=[], http_version="1.0")
     assert r.status_code == HTTPStatus.OK

--- a/h11/tests/test_util.py
+++ b/h11/tests/test_util.py
@@ -93,7 +93,7 @@ def test_bytesify():
     assert bytesify("123") == b"123"
 
     with pytest.raises(UnicodeEncodeError):
-        bytesify(u"\u1234")
+        bytesify("\u1234")
 
     with pytest.raises(TypeError):
         bytesify(10)

--- a/newsfragments/114.removal.rst
+++ b/newsfragments/114.removal.rst
@@ -1,0 +1,2 @@
+Python 2.7 and PyPy 2 support is removed. h11 now requires Python>=3.5 including PyPy 3.
+Users running `pip install h11` on Python 2 will automatically get the last Python 2-compatible version.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [isort]
 combine_as_imports=True
 force_grid_wrap=0

--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,15 @@ setup(
     # This means, just install *everything* you see under h11/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = format, py27, py36, py37, py38, pypy, pypy3
+envlist = format, py36, py37, py38, pypy3
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38, format
-    pypy2: pypy
     pypy3: pypy3
 
 [testenv]


### PR DESCRIPTION
Blocked on #115 / 0.12.0 release, will be updated afterwards.

Fixes #114.

Python 2 support in this library is not too onerous, the main reason for doing this is to allow using newer Python features like inline type annotations.

In the documentation/README updates I assume that this will be released in a 0.12.x series rather than the latest 0.11.x series which supports Python 2. I think it would be good to branch off 0.11.x just in case we ever want to backport some bug fixes to a Python 2-compatible version.

I updated whatever I could find except for the `ReceiveBuffer. According to the [comment](https://github.com/python-hyper/h11/blob/522b00470b5776dda2dc7e98ff778eb1e418e6ad/h11/_receivebuffer.py#L20-L40) there it can be simplified after Python 2 is dropped but needs some care. I will look at it in a separate PR unless someone else wants to update this part.