### PR TITLE
Get rid of _EventBundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - 2.7
         - 3.6
         - 3.7
         - 3.8
-        - pypy2
         - pypy3
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,10 +70,10 @@ other hand, the following are all very welcome:
   tox
   ```
 
-  But note that: (1) this will print slightly misleading coverage
+  But note that: (1) this might print slightly misleading coverage
   statistics, because it only shows coverage for individual python
-  versions, and there are some lines that are only executed on python
-  2 or only executed on python 3, and (2) the full test suite will
+  versions, and there might be some lines that are only executed on some
+  python versions or implementations, and (2) the full test suite will
   automatically get run when you submit a pull request, so you don't
   need to worry too much about tracking down a version of cpython 3.3
   or whatever just to run the tests.

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,8 @@ library.
 It has a test suite with 100.0% coverage for both statements and
 branches.
 
-Currently it supports Python 3 (testing on 3.5-3.8), Python 2.7, and PyPy.
+Currently it supports Python 3 (testing on 3.5-3.8) and PyPy 3.
+The last Python 2-compatible version was h11 0.11.x.
 (Originally it had a Cython wrapper for `http-parser
 <https://github.com/nodejs/http-parser>`_ and a beautiful nested state
 machine implemented with ``yield from`` to postprocess the output. But

--- a/bench/asv.conf.json
+++ b/bench/asv.conf.json
@@ -36,7 +36,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["2.7", "3.5", "pypy"],
+    "pythons": ["3.8", "pypy3"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,9 @@ whatever. But h11 makes it much easier to implement something like
 Vital statistics
 ----------------
 
-* Requirements: Python 2.7 or Python 3.5+ (PyPy works great)
+* Requirements: Python 3.5+ (PyPy works great)
+
+  The last Python 2-compatible version was h11 0.11.x.
 
 * Install: ``pip install h11``
 

--- a/fuzz/afl-server.py
+++ b/fuzz/afl-server.py
@@ -9,11 +9,6 @@ import afl
 
 import h11
 
-if sys.version_info[0] >= 3:
-    in_file = sys.stdin.detach()
-else:
-    in_file = sys.stdin
-
 
 def process_all(c):
     while True:
@@ -26,7 +21,7 @@ def process_all(c):
 
 afl.init()
 
-data = in_file.read()
+data = sys.stdin.detach().read()
 
 # one big chunk
 server1 = h11.Connection(h11.SERVER)

--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -109,7 +109,7 @@ def _body_framing(request_method, event):
 ################################################################
 
 
-class Connection(object):
+class Connection:
     """An object encapsulating the state of an HTTP connection.
 
     Args:

--- a/h11/_events.py
+++ b/h11/_events.py
@@ -24,7 +24,7 @@ __all__ = [
 request_target_re = re.compile(request_target.encode("ascii"))
 
 
-class _EventBundle(object):
+class _EventBundle:
     _fields = []
     _defaults = {}
 
@@ -84,9 +84,6 @@ class _EventBundle(object):
     # Useful for tests
     def __eq__(self, other):
         return self.__class__ == other.__class__ and self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     # This is an unhashable type.
     __hash__ = None

--- a/h11/_events.py
+++ b/h11/_events.py
@@ -24,72 +24,7 @@ __all__ = [
 request_target_re = re.compile(request_target.encode("ascii"))
 
 
-class _EventBundle:
-    _fields = []
-    _defaults = {}
-
-    def __init__(self, **kwargs):
-        _parsed = kwargs.pop("_parsed", False)
-        allowed = set(self._fields)
-        for kwarg in kwargs:
-            if kwarg not in allowed:
-                raise TypeError(
-                    "unrecognized kwarg {} for {}".format(
-                        kwarg, self.__class__.__name__
-                    )
-                )
-        required = allowed.difference(self._defaults)
-        for field in required:
-            if field not in kwargs:
-                raise TypeError(
-                    "missing required kwarg {} for {}".format(
-                        field, self.__class__.__name__
-                    )
-                )
-        self.__dict__.update(self._defaults)
-        self.__dict__.update(kwargs)
-
-        # Special handling for some fields
-
-        if "headers" in self.__dict__:
-            self.headers = _headers.normalize_and_validate(
-                self.headers, _parsed=_parsed
-            )
-
-        if not _parsed:
-            for field in ["method", "target", "http_version", "reason"]:
-                if field in self.__dict__:
-                    self.__dict__[field] = bytesify(self.__dict__[field])
-
-            if "status_code" in self.__dict__:
-                if not isinstance(self.status_code, int):
-                    raise LocalProtocolError("status code must be integer")
-                # Because IntEnum objects are instances of int, but aren't
-                # duck-compatible (sigh), see gh-72.
-                self.status_code = int(self.status_code)
-
-        self._validate()
-
-    def _validate(self):
-        pass
-
-    def __repr__(self):
-        name = self.__class__.__name__
-        kwarg_strs = [
-            "{}={}".format(field, self.__dict__[field]) for field in self._fields
-        ]
-        kwarg_str = ", ".join(kwarg_strs)
-        return "{}({})".format(name, kwarg_str)
-
-    # Useful for tests
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.__dict__ == other.__dict__
-
-    # This is an unhashable type.
-    __hash__ = None
-
-
-class Request(_EventBundle):
+class Request:
     """The beginning of an HTTP request.
 
     Fields:
@@ -123,10 +58,19 @@ class Request(_EventBundle):
 
     """
 
-    _fields = ["method", "target", "headers", "http_version"]
-    _defaults = {"http_version": b"1.1"}
+    __slots__ = ("method", "target", "headers", "http_version")
 
-    def _validate(self):
+    def __init__(self, method, target, headers, http_version=b"1.1", _parsed=False):
+        self.headers = _headers.normalize_and_validate(headers, _parsed=_parsed)
+        self.http_version = bytesify(http_version)
+
+        if _parsed:
+            self.method = method
+            self.target = target
+        else:
+            self.method = bytesify(method)
+            self.target = bytesify(target)
+
         # "A server MUST respond with a 400 (Bad Request) status code to any
         # HTTP/1.1 request message that lacks a Host header field and to any
         # request message that contains more than one Host header field or a
@@ -143,13 +87,31 @@ class Request(_EventBundle):
 
         validate(request_target_re, self.target, "Illegal target characters")
 
+    def __repr__(self):
+        return "{}(method={}, target={}, headers={}, http_version={})".format(
+            self.__class__.__name__,
+            self.method,
+            self.target,
+            self.headers,
+            self.http_version,
+        )
 
-class _ResponseBase(_EventBundle):
-    _fields = ["status_code", "headers", "http_version", "reason"]
-    _defaults = {"http_version": b"1.1", "reason": b""}
+    # Useful for tests
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return (
+            self.method == other.method
+            and self.target == other.target
+            and self.headers == other.headers
+            and self.http_version == other.http_version
+        )
+
+    # This is an unhashable type.
+    __hash__ = None
 
 
-class InformationalResponse(_ResponseBase):
+class InformationalResponse:
     """An HTTP informational response.
 
     Fields:
@@ -179,15 +141,57 @@ class InformationalResponse(_ResponseBase):
 
     """
 
-    def _validate(self):
+    __slots__ = ("status_code", "headers", "http_version", "reason")
+
+    def __init__(
+        self, status_code, headers, http_version=b"1.1", reason=b"", _parsed=False
+    ):
+        self.status_code = status_code
+        self.headers = _headers.normalize_and_validate(headers, _parsed=_parsed)
+
+        if _parsed:
+            self.http_version = http_version
+            self.reason = reason
+        else:
+            self.http_version = bytesify(http_version)
+            self.reason = bytesify(reason)
+            if not isinstance(self.status_code, int):
+                raise LocalProtocolError("status code must be integer")
+            # Because IntEnum objects are instances of int, but aren't
+            # duck-compatible (sigh), see gh-72.
+            self.status_code = int(self.status_code)
+
         if not (100 <= self.status_code < 200):
             raise LocalProtocolError(
                 "InformationalResponse status_code should be in range "
                 "[100, 200), not {}".format(self.status_code)
             )
 
+    def __repr__(self):
+        return "{}(status_code={}, headers={}, http_version={}, reason={})".format(
+            self.__class__.__name__,
+            self.status_code,
+            self.headers,
+            self.http_version,
+            self.reason,
+        )
 
-class Response(_ResponseBase):
+    # Useful for tests
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return (
+            self.status_code == other.status_code
+            and self.headers == other.headers
+            and self.http_version == other.http_version
+            and self.reason == other.reason
+        )
+
+    # This is an unhashable type.
+    __hash__ = None
+
+
+class Response:
     """The beginning of an HTTP response.
 
     Fields:
@@ -216,7 +220,26 @@ class Response(_ResponseBase):
 
     """
 
-    def _validate(self):
+    __slots__ = ("status_code", "headers", "http_version", "reason")
+
+    def __init__(
+        self, status_code, headers, http_version=b"1.1", reason=b"", _parsed=False
+    ):
+        self.status_code = status_code
+        self.headers = _headers.normalize_and_validate(headers, _parsed=_parsed)
+
+        if _parsed:
+            self.http_version = http_version
+            self.reason = reason
+        else:
+            self.http_version = bytesify(http_version)
+            self.reason = bytesify(reason)
+            if not isinstance(self.status_code, int):
+                raise LocalProtocolError("status code must be integer")
+            # Because IntEnum objects are instances of int, but aren't
+            # duck-compatible (sigh), see gh-72.
+            self.status_code = int(self.status_code)
+
         if not (200 <= self.status_code < 600):
             raise LocalProtocolError(
                 "Response status_code should be in range [200, 600), not {}".format(
@@ -224,8 +247,31 @@ class Response(_ResponseBase):
                 )
             )
 
+    def __repr__(self):
+        return "{}(status_code={}, headers={}, http_version={}, reason={})".format(
+            self.__class__.__name__,
+            self.status_code,
+            self.headers,
+            self.http_version,
+            self.reason,
+        )
 
-class Data(_EventBundle):
+    # Useful for tests
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return (
+            self.status_code == other.status_code
+            and self.headers == other.headers
+            and self.http_version == other.http_version
+            and self.reason == other.reason
+        )
+
+    # This is an unhashable type.
+    __hash__ = None
+
+
+class Data:
     """Part of an HTTP message body.
 
     Fields:
@@ -258,8 +304,33 @@ class Data(_EventBundle):
 
     """
 
-    _fields = ["data", "chunk_start", "chunk_end"]
-    _defaults = {"chunk_start": False, "chunk_end": False}
+    __slots__ = ("data", "chunk_start", "chunk_end")
+
+    def __init__(self, data, chunk_start=False, chunk_end=False):
+        self.data = data
+        self.chunk_start = chunk_start
+        self.chunk_end = chunk_end
+
+    def __repr__(self):
+        return "{}(data={}, chunk_start={}, chunk_end={})".format(
+            self.__class__.__name__,
+            self.data,
+            self.chunk_start,
+            self.chunk_end,
+        )
+
+    # Useful for tests
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return (
+            self.data == other.data
+            and self.chunk_start == other.chunk_start
+            and self.chunk_end == other.chunk_end
+        )
+
+    # This is an unhashable type.
+    __hash__ = None
 
 
 # XX FIXME: "A recipient MUST ignore (or consider as an error) any fields that
@@ -267,7 +338,7 @@ class Data(_EventBundle):
 # present in the header section might bypass external security filters."
 # https://svn.tools.ietf.org/svn/wg/httpbis/specs/rfc7230.html#chunked.trailer.part
 # Unfortunately, the list of forbidden fields is long and vague :-/
-class EndOfMessage(_EventBundle):
+class EndOfMessage:
     """The end of an HTTP message.
 
     Fields:
@@ -284,11 +355,28 @@ class EndOfMessage(_EventBundle):
 
     """
 
-    _fields = ["headers"]
-    _defaults = {"headers": []}
+    __slots__ = ("headers",)
+
+    def __init__(self, headers=[], _parsed=False):
+        self.headers = _headers.normalize_and_validate(headers, _parsed=_parsed)
+
+    def __repr__(self):
+        return "{}(headers={})".format(
+            self.__class__.__name__,
+            self.headers,
+        )
+
+    # Useful for tests
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.headers == other.headers
+
+    # This is an unhashable type.
+    __hash__ = None
 
 
-class ConnectionClosed(_EventBundle):
+class ConnectionClosed:
     """This event indicates that the sender has closed their outgoing
     connection.
 
@@ -299,4 +387,18 @@ class ConnectionClosed(_EventBundle):
     No fields.
     """
 
-    pass
+    __slots__ = ()
+
+    def __repr__(self):
+        return "{}()".format(
+            self.__class__.__name__,
+        )
+
+    # Useful for tests
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return True
+
+    # This is an unhashable type.
+    __hash__ = None

--- a/h11/_headers.py
+++ b/h11/_headers.py
@@ -132,7 +132,7 @@ def normalize_and_validate(headers, _parsed=False):
         raw_name = name
         name = name.lower()
         if name == b"content-length":
-            lengths = set(length.strip() for length in value.split(b","))
+            lengths = {length.strip() for length in value.split(b",")}
             if len(lengths) != 1:
                 raise LocalProtocolError("conflicting Content-Length headers")
             value = lengths.pop()

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -1,5 +1,3 @@
-import sys
-
 __all__ = ["ReceiveBuffer"]
 
 
@@ -38,7 +36,7 @@ __all__ = ["ReceiveBuffer"]
 # slightly clever thing where we delay calling compress() until we've
 # processed a whole event, which could in theory be slightly more efficient
 # than the internal bytearray support.)
-class ReceiveBuffer(object):
+class ReceiveBuffer:
     def __init__(self):
         self._data = bytearray()
         # These are both absolute offsets into self._data:
@@ -52,10 +50,6 @@ class ReceiveBuffer(object):
     # for @property unprocessed_data
     def __bytes__(self):
         return bytes(self._data[self._start :])
-
-    if sys.version_info[0] < 3:  # version specific: Python 2
-        __str__ = __bytes__
-        __nonzero__ = __bool__
 
     def __len__(self):
         return len(self._data) - self._start

--- a/h11/_state.py
+++ b/h11/_state.py
@@ -197,7 +197,7 @@ STATE_TRIGGERED_TRANSITIONS = {
 }
 
 
-class ConnectionState(object):
+class ConnectionState:
     def __init__(self):
         # Extra bits of state that don't quite fit into the state model.
 

--- a/h11/_util.py
+++ b/h11/_util.py
@@ -1,6 +1,3 @@
-import re
-import sys
-
 __all__ = [
     "ProtocolError",
     "LocalProtocolError",
@@ -74,34 +71,17 @@ class LocalProtocolError(ProtocolError):
         # (exc_info[0]) separately from the exception object (exc_info[1]),
         # and we only modified the latter. So we really do need to re-raise
         # the new type explicitly.
-        if sys.version_info[0] >= 3:
-            # On py3, the traceback is part of the exception object, so our
-            # in-place modification preserved it and we can just re-raise:
-            raise self
-        else:
-            # On py2, preserving the traceback requires 3-argument
-            # raise... but on py3 this is a syntax error, so we have to hide
-            # it inside an exec
-            exec("raise RemoteProtocolError, self, sys.exc_info()[2]")
+        # On py3, the traceback is part of the exception object, so our
+        # in-place modification preserved it and we can just re-raise:
+        raise self
 
 
 class RemoteProtocolError(ProtocolError):
     pass
 
 
-try:
-    _fullmatch = type(re.compile("")).fullmatch
-except AttributeError:
-
-    def _fullmatch(regex, data):  # version specific: Python < 3.4
-        match = regex.match(data)
-        if match and match.end() != len(data):
-            match = None
-        return match
-
-
 def validate(regex, data, msg="malformed data", *format_args):
-    match = _fullmatch(regex, data)
+    match = regex.fullmatch(data)
     if not match:
         if format_args:
             msg = msg.format(*format_args)

--- a/h11/tests/test_against_stdlib_http.py
+++ b/h11/tests/test_against_stdlib_http.py
@@ -1,25 +1,13 @@
 import json
 import os.path
 import socket
+import socketserver
 import threading
 from contextlib import closing, contextmanager
+from http.server import SimpleHTTPRequestHandler
+from urllib.request import urlopen
 
 import h11
-
-try:
-    from urllib.request import urlopen
-except ImportError:  # version specific: Python 2
-    from urllib2 import urlopen
-
-try:
-    import socketserver
-except ImportError:  # version specific: Python 2
-    import SocketServer as socketserver
-
-try:
-    from http.server import SimpleHTTPRequestHandler
-except ImportError:  # version specific: Python 2
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
 
 
 @contextmanager

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 import pytest
 
 from .. import _events
@@ -154,10 +156,6 @@ def test_events():
 
 def test_intenum_status_code():
     # https://github.com/python-hyper/h11/issues/72
-    try:
-        from http import HTTPStatus
-    except ImportError:
-        pytest.skip("Only affects Python 3")
 
     r = Response(status_code=HTTPStatus.OK, headers=[], http_version="1.0")
     assert r.status_code == HTTPStatus.OK

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -7,52 +7,6 @@ from .._events import *
 from .._util import LocalProtocolError
 
 
-def test_event_bundle():
-    class T(_events._EventBundle):
-        _fields = ["a", "b"]
-        _defaults = {"b": 1}
-
-        def _validate(self):
-            if self.a == 0:
-                raise ValueError
-
-    # basic construction and methods
-    t = T(a=1, b=0)
-    assert repr(t) == "T(a=1, b=0)"
-    assert t == T(a=1, b=0)
-    assert not (t == T(a=2, b=0))
-    assert not (t != T(a=1, b=0))
-    assert t != T(a=2, b=0)
-    with pytest.raises(TypeError):
-        hash(t)
-
-    # check defaults
-    t = T(a=10)
-    assert t.a == 10
-    assert t.b == 1
-
-    # no positional args
-    with pytest.raises(TypeError):
-        T(1)
-
-    with pytest.raises(TypeError):
-        T(1, a=1, b=0)
-
-    # unknown field
-    with pytest.raises(TypeError):
-        T(a=1, b=0, c=10)
-
-    # missing required field
-    with pytest.raises(TypeError) as exc:
-        T(b=0)
-    # make sure we error on the right missing kwarg
-    assert "kwarg a" in str(exc.value)
-
-    # _validate is called
-    with pytest.raises(ValueError):
-        T(a=0, b=0)
-
-
 def test_events():
     with pytest.raises(LocalProtocolError):
         # Missing Host:
@@ -66,6 +20,10 @@ def test_events():
     assert req.target == b"/"
     assert req.headers == [(b"a", b"b")]
     assert req.http_version == b"1.0"
+    assert repr(req) == (
+        "Request(method=b'GET', target=b'/', "
+        "headers=<Headers([(b'a', b'b')])>, http_version=b'1.0')"
+    )
 
     # This is also okay -- has a Host (with weird capitalization, which is ok)
     req = Request(
@@ -126,6 +84,10 @@ def test_events():
     assert ir.status_code == 100
     assert ir.headers == [(b"host", b"a")]
     assert ir.http_version == b"1.1"
+    assert repr(ir) == (
+        "InformationalResponse(status_code=100, headers=<Headers([(b'host', b'a')])>, "
+        "http_version=b'1.1', reason=b'')"
+    )
 
     with pytest.raises(LocalProtocolError):
         InformationalResponse(status_code=200, headers=[("Host", "a")])
@@ -146,9 +108,11 @@ def test_events():
 
     d = Data(data=b"asdf")
     assert d.data == b"asdf"
+    assert repr(d) == "Data(data=b'asdf', chunk_start=False, chunk_end=False)"
 
     eom = EndOfMessage()
     assert eom.headers == []
+    assert repr(eom) == "EndOfMessage(headers=<Headers([])>)"
 
     cc = ConnectionClosed()
     assert repr(cc) == "ConnectionClosed()"

--- a/h11/tests/test_util.py
+++ b/h11/tests/test_util.py
@@ -93,7 +93,7 @@ def test_bytesify():
     assert bytesify("123") == b"123"
 
     with pytest.raises(UnicodeEncodeError):
-        bytesify(u"\u1234")
+        bytesify("\u1234")
 
     with pytest.raises(TypeError):
         bytesify(10)

--- a/newsfragments/114.removal.rst
+++ b/newsfragments/114.removal.rst
@@ -1,0 +1,2 @@
+Python 2.7 and PyPy 2 support is removed. h11 now requires Python>=3.5 including PyPy 3.
+Users running `pip install h11` on Python 2 will automatically get the last Python 2-compatible version.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [isort]
 combine_as_imports=True
 force_grid_wrap=0

--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,15 @@ setup(
     # This means, just install *everything* you see under h11/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = format, py27, py36, py37, py38, pypy, pypy3
+envlist = format, py36, py37, py38, pypy3
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38, format
-    pypy2: pypy
     pypy3: pypy3
 
 [testenv]


### PR DESCRIPTION
This is based on #116 so you can ignore the first commit.

`_EventBundle` uses a lot of dynamic python features to save on some duplication, but it slows things down, and will also make it much harder to add static typing. Since these types are now pretty stable, it seems not worth it.

On the bench/ micro-benchmark:

```
Before:  9322.6 requests/sec
After : 10544.6 requests/sec
```