### PR TITLE
Use native bytearray truncation

### DIFF
--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -425,7 +425,6 @@ class Connection(object):
             event = self._extract_next_receive_event()
             if event not in [NEED_DATA, PAUSED]:
                 self._process_event(self.their_role, event)
-                self._receive_buffer.compress()
             if event is NEED_DATA:
                 if len(self._receive_buffer) > self._max_incomplete_event_size:
                     # 431 is "Request header fields too large" which is pretty

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -45,8 +45,8 @@ class ReceiveBuffer(object):
         out = self._data[:count]
         if not out:
             return None
-        # Note that front-truncation of bytesarray is O(1), from Python 3.4
-        # onwards, thanks to some excellent work by Antoine Pitrou:
+        # Note that front-truncation of bytesarray is amortized O(1), from
+        # Python 3.4 onwards, thanks to some excellent work by Antoine Pitrou:
         #
         # https://bugs.python.org/issue19087
         del self._data[:count]

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -16,28 +16,6 @@ __all__ = ["ReceiveBuffer"]
 #   of constantly copying
 # WARNING:
 # - I haven't benchmarked or profiled any of this yet.
-#
-# Note that starting in Python 3.4, deleting the initial n bytes from a
-# bytearray is amortized O(n), thanks to some excellent work by Antoine
-# Martin:
-#
-#     https://bugs.python.org/issue19087
-#
-# This means that if we only supported 3.4+, we could get rid of the code here
-# involving self._start and self.compress, because it's doing exactly the same
-# thing that bytearray now does internally.
-#
-# BUT unfortunately, we still support 2.7, and reading short segments out of a
-# long buffer MUST be O(bytes read) to avoid DoS issues, so we can't actually
-# delete this code. Yet:
-#
-#     https://pythonclock.org/
-#
-# (Two things to double-check first though: make sure PyPy also has the
-# optimization, and benchmark to make sure it's a win, since we do have a
-# slightly clever thing where we delay calling compress() until we've
-# processed a whole event, which could in theory be slightly more efficient
-# than the internal bytearray support.)
 class ReceiveBuffer(object):
     def __init__(self):
         self._data = bytearray()

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -46,7 +46,7 @@ class ReceiveBuffer(object):
         if not out:
             return None
         # Note that front-truncation of bytesarray is amortized O(n), from
-        # Python 3.4 onwards, thanks to some excellent work by Antoine Martin:
+        # Python 3.4 onwards, thanks to some excellent work by Antoine Pitrou:
         #
         # https://bugs.python.org/issue19087
         del self._data[:count]

--- a/h11/_receivebuffer.py
+++ b/h11/_receivebuffer.py
@@ -45,8 +45,8 @@ class ReceiveBuffer(object):
         out = self._data[:count]
         if not out:
             return None
-        # Note that front-truncation of bytesarray is amortized O(n), from
-        # Python 3.4 onwards, thanks to some excellent work by Antoine Pitrou:
+        # Note that front-truncation of bytesarray is O(1), from Python 3.4
+        # onwards, thanks to some excellent work by Antoine Pitrou:
         #
         # https://bugs.python.org/issue19087
         del self._data[:count]

--- a/h11/tests/test_receivebuffer.py
+++ b/h11/tests/test_receivebuffer.py
@@ -12,7 +12,6 @@ def test_receivebuffer():
     assert len(b) == 3
     assert bytes(b) == b"123"
 
-    b.compress()
     assert bytes(b) == b"123"
 
     assert b.maybe_extract_at_most(2) == b"12"
@@ -20,7 +19,6 @@ def test_receivebuffer():
     assert len(b) == 1
     assert bytes(b) == b"3"
 
-    b.compress()
     assert bytes(b) == b"3"
 
     assert b.maybe_extract_at_most(10) == b"3"


### PR DESCRIPTION
Switching from `.compress()` to using native buffer truncation.

I figure despite some related work on #115 it's worth looking at this PR in isolation.

We probably want this to be blocked on #116.

Benchmarking on Python 3.7...

Before:

```python
$ PYTHONPATH=. venv/bin/python bench/benchmarks/benchmarks.py
6901.9 requests/sec
7055.0 requests/sec
7084.2 requests/sec
7070.6 requests/sec
7107.9 requests/sec
7075.8 requests/sec
7079.4 requests/sec

$ PYTHONPATH=. venv/bin/python bench/benchmarks/benchmarks.py
6972.9 requests/sec
6996.9 requests/sec
6947.3 requests/sec
6999.9 requests/sec
7040.6 requests/sec
7030.0 requests/sec
6997.6 requests/sec
```

After:

```python
$ PYTHONPATH=. venv/bin/python bench/benchmarks/benchmarks.py
7054.6 requests/sec
7133.3 requests/sec
7148.3 requests/sec
7116.4 requests/sec
7121.0 requests/sec
7128.2 requests/sec
7156.5 requests/sec

$ PYTHONPATH=. venv/bin/python bench/benchmarks/benchmarks.py
7018.9 requests/sec
7074.7 requests/sec
7075.0 requests/sec
7070.6 requests/sec
7028.2 requests/sec
7118.3 requests/sec
7131.2 requests/sec
```