### PR TITLE
Clarify which Python versions are supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ library.
 It has a test suite with 100.0% coverage for both statements and
 branches.
 
-Currently it supports Python 3 (testing on 3.5-3.8) and PyPy 3.
+Currently it supports Python 3 (testing on 3.6-3.9) and PyPy 3.
 The last Python 2-compatible version was h11 0.11.x.
 (Originally it had a Cython wrapper for `http-parser
 <https://github.com/nodejs/http-parser>`_ and a beautiful nested state

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ whatever. But h11 makes it much easier to implement something like
 Vital statistics
 ----------------
 
-* Requirements: Python 3.5+ (PyPy works great)
+* Requirements: Python 3.6+ (PyPy works great)
 
   The last Python 2-compatible version was h11 0.11.x.
 

--- a/newsfragments/114.removal.rst
+++ b/newsfragments/114.removal.rst
@@ -1,2 +1,2 @@
-Python 2.7 and PyPy 2 support is removed. h11 now requires Python>=3.5 including PyPy 3.
+Python 2.7 and PyPy 2 support is removed. h11 now requires Python>=3.6 including PyPy 3.
 Users running `pip install h11` on Python 2 will automatically get the last Python 2-compatible version.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # This means, just install *everything* you see under h11/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -26,10 +26,10 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: System :: Networking",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = format, py36, py37, py38, pypy3
+envlist = format, py36, py37, py38, py39, pypy3
 
 [gh-actions]
 python =
     3.6: py36
     3.7: py37
     3.8: py38, format
+    3.9: py39
     pypy3: pypy3
 
 [testenv]


### PR DESCRIPTION
Following on from 4746b0a0fff341b70aaa4032b7fa49f613a1b586 Python 3.5
is not supported (has reached EoL) and 3.9 is (has been released).