### PR TITLE
Shorten traceback of protocol errors.

### DIFF
--- a/h11/_state.py
+++ b/h11/_state.py
@@ -252,7 +252,7 @@ class ConnectionState:
                 "can't handle event type {} when role={} and state={}".format(
                     event_type.__name__, role, self.states[role]
                 )
-            )
+            ) from None
         self.states[role] = new_state
 
     def _fire_state_triggered_transitions(self):


### PR DESCRIPTION
This is a minor change for a slightly more readable logs.

At the moment, when a protocol error is raised its traceback looks like: 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/h11/_state.py", line 249, in _fire_event_triggered_transitions
    new_state = EVENT_TRIGGERED_TRANSITIONS[role][state][event_type]
KeyError: <class 'h11._events.ConnectionClosed'>
During handling of the above exception, another exception occurred:
   ...
h11._util.RemoteProtocolError: can't handle event type ConnectionClosed when role=SERVER and state=SEND_RESPONSE
```

The `KeyError` at the top is just an implementation detail and does not need to be in tracebacks.