### PR TITLE
Change supported Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,12 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9
-        - pypy3
+        - "3.10"
+        - pypy-3.7
+        - pypy-3.8
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ library.
 It has a test suite with 100.0% coverage for both statements and
 branches.
 
-Currently it supports Python 3 (testing on 3.6-3.9) and PyPy 3.
+Currently it supports Python 3 (testing on 3.7-3.10) and PyPy 3.
 The last Python 2-compatible version was h11 0.11.x.
 (Originally it had a Cython wrapper for `http-parser
 <https://github.com/nodejs/http-parser>`_ and a beautiful nested state

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ whatever. But h11 makes it much easier to implement something like
 Vital statistics
 ----------------
 
-* Requirements: Python 3.6+ (PyPy works great)
+* Requirements: Python 3.7+ (PyPy works great)
 
   The last Python 2-compatible version was h11 0.11.x.
 

--- a/newsfragments/138.removal.rst
+++ b/newsfragments/138.removal.rst
@@ -1,0 +1,3 @@
+Python 3.6 support is removed. h11 now requires Python>=3.7 including
+PyPy 3.  Users running `pip install h11` on Python 2 will
+automatically get the last Python 2-compatible version.

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,8 @@ setup(
     # This means, just install *everything* you see under h11/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
-        "dataclasses; python_version < '3.7'",
         "typing_extensions; python_version < '3.8'",
     ],
     classifiers=[
@@ -31,10 +30,10 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: System :: Networking",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,21 @@
 [tox]
-envlist = format, py36, py37, py38, py39, pypy3, mypy
+envlist = format, py37, py38, py39, py310, pypy3, mypyp
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
-    3.8: py38, format, mypy
+    3.8: py38
     3.9: py39
-    pypy3: pypy3
+    3.10: py310, format, mypy
+    pypy-3.7: pypy3
+    pypy-3.8: pypy3
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 commands = pytest --cov=h11 --cov-config=.coveragerc h11
 
 [testenv:format]
-basepython = python3.8
+basepython = python3.10
 deps =
     black
     isort


### PR DESCRIPTION
Python 3.6 is at EOL and 3.10 was released around 2 months ago. This
allows the conditional dataclasses requirement to be removed.