### PR TITLE
Ensure request method is a valid token

### DIFF
--- a/h11/_events.py
+++ b/h11/_events.py
@@ -10,7 +10,7 @@ from abc import ABC
 from dataclasses import dataclass, field
 from typing import Any, cast, Dict, List, Tuple, Union
 
-from ._abnf import request_target
+from ._abnf import method, request_target
 from ._headers import Headers, normalize_and_validate
 from ._util import bytesify, LocalProtocolError, validate
 
@@ -25,6 +25,7 @@ __all__ = [
     "ConnectionClosed",
 ]
 
+method_re = re.compile(method.encode("ascii"))
 request_target_re = re.compile(request_target.encode("ascii"))
 
 
@@ -117,6 +118,7 @@ class Request(Event):
         if host_count > 1:
             raise LocalProtocolError("Found multiple Host: headers")
 
+        validate(method_re, self.method, "Illegal method characters")
         validate(request_target_re, self.target, "Illegal target characters")
 
     # This is an unhashable type.

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -90,7 +90,7 @@ def test_events() -> None:
             method="GET / HTTP/1.1",
             target=target,
             headers=[("Host", "a")],
-            http_version="1.1"
+            http_version="1.1",
         )
 
     ir = InformationalResponse(status_code=100, headers=[("Host", "a")])

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -84,6 +84,15 @@ def test_events() -> None:
                 method="GET", target=target, headers=[("Host", "a")], http_version="1.1"
             )
 
+    # Request method is validated
+    with pytest.raises(LocalProtocolError):
+        Request(
+            method="GET / HTTP/1.1",
+            target=target,
+            headers=[("Host", "a")],
+            http_version="1.1"
+        )
+
     ir = InformationalResponse(status_code=100, headers=[("Host", "a")])
     assert ir.status_code == 100
     assert ir.headers == [(b"host", b"a")]


### PR DESCRIPTION
We're currently validating the request target and raising a `LocalProtocolError` when it's invalid.
We ought to also extend this to the request method.