### PR TITLE
GitHub action for automated deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: "Publish release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+      - name: "Install dependancies"
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install --upgrade twine wheel
+      - name: "Build package"
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: "Publish to PyPI"
+        run: |
+          twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Hi folks 👋🏼

Here's a pass at what I think we'd need in order to have automated deployments, triggered by tagging a GitHub release.

* A PyPI API token would [need to be created for the package](https://pypi.org/help/#apitoken).
* The API token then needs to be [added as `PYPI_TOKEN` in the repo settings](https://github.com/python-hyper/h11/settings/secrets/actions).

The PR would perhaps also need to be fleshed out with something like a `DEPLOYMENT.md` text (or similar?) to describe the release process.