### PR TITLE
Better handle of trailing spaces on chunk header - Fixes issue #133

### DIFF
--- a/h11/_abnf.py
+++ b/h11/_abnf.py
@@ -125,5 +125,5 @@ chunk_ext = r";.*"
 chunk_header = (
     r"(?P<chunk_size>{chunk_size})"
     r"(?P<chunk_ext>{chunk_ext})?"
-    r"\r\n".format(**globals())
+    r"\s*\r\n".format(**globals())
 )

--- a/h11/_abnf.py
+++ b/h11/_abnf.py
@@ -125,5 +125,6 @@ chunk_ext = r";.*"
 chunk_header = (
     r"(?P<chunk_size>{chunk_size})"
     r"(?P<chunk_ext>{chunk_ext})?"
-    r"{OWS}\r\n".format(**globals())
+    r"{OWS}\r\n".format(**globals())  # Even though the specification does not allow for extra whitespaces, 
+    # we are lenient with trailing whitespaces because some servers on the wild use it.
 )

--- a/h11/_abnf.py
+++ b/h11/_abnf.py
@@ -125,5 +125,5 @@ chunk_ext = r";.*"
 chunk_header = (
     r"(?P<chunk_size>{chunk_size})"
     r"(?P<chunk_ext>{chunk_ext})?"
-    r"\s*\r\n".format(**globals())
+    r"{OWS}\r\n".format(**globals())
 )


### PR DESCRIPTION
Hello,

I found some servers that return multiple trailing spaces on the chunk header. I changed the regex to match on those cases. This fixes issue #133