### PR TITLE
Update `next_event` annotation to reflect possible return types

### DIFF
--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -421,7 +421,7 @@ class Connection:
             event = NEED_DATA
         return event  # type: ignore[no-any-return]
 
-    def next_event(self) -> Union[Event, Type[Sentinel]]:
+    def next_event(self) -> Union[Event, NEED_DATA, PAUSED]:
         """Parse the next event out of our receive buffer, update our internal
         state, and return it.
 


### PR DESCRIPTION
Hi! I'm updating httpcore's type annotations (https://github.com/encode/httpcore/pull/526) to be compatible with the latest h11 version and encountering a difficulty with the type annotations on `next_event`. Since the return type includes `Sentinel` which is a private type in h11, the return type in httpcore cannot be defined correctly.

To resolve this, the `Sentinel` type could be exposed publicly. However, arbitrary sentinels cannot be handled by downstream libraries. Instead, they should have a well defined set of sentinels that they know to handle. `NEEDS_DATA` and `PAUSED` are already publicly exposed and are the two sentinel types that can be returned by `needs_data`. Narrowing the type definition to these specific types will confer to consumers that they should handle these explicit sentinel types. If you add more sentinel types in the future, type checkers will warn users that they are not handling all of the possible return types for this function.

There may be other `Sentinel` return type annotations that could/should be updated as well.