### PR TITLE
Call `conn.send_failed` if `stream.send_all` fails with an exception.

### DIFF
--- a/examples/trio-server.py
+++ b/examples/trio-server.py
@@ -114,7 +114,13 @@ class TrioHTTPWrapper:
         # appropriate when 'data' is None.
         assert type(event) is not h11.ConnectionClosed
         data = self.conn.send(event)
-        await self.stream.send_all(data)
+        try:
+            await self.stream.send_all(data)
+        except BaseException:
+            # If send_all raises an exception (especially trio.Cancelled),
+            # we have no choice but to give it up.
+            self.conn.send_failed()
+            raise
 
     async def _read_from_peer(self):
         if self.conn.they_are_waiting_for_100_continue:


### PR DESCRIPTION
See details:

[1] https://trio.readthedocs.io/en/latest/reference-io.html#trio.abc.SendStream.send_all
[2] https://h11.readthedocs.io/en/latest/api.html#h11.Connection.send_failed