### PR TITLE
Remove python version in trio-server.py

### DIFF
--- a/examples/trio-server.py
+++ b/examples/trio-server.py
@@ -1,6 +1,5 @@
 # A simple HTTP server implemented using h11 and Trio:
 #   http://trio.readthedocs.io/en/latest/index.html
-# (so requires python 3.5+).
 #
 # All requests get echoed back a JSON document containing information about
 # the request.


### PR DESCRIPTION
Now trio 0.20.0 requires python 3.7 or later. But IMO it's not necessary to mention it here and update it every year.