### PR TITLE
Format with black 23.3.0

### DIFF
--- a/examples/trio-server.py
+++ b/examples/trio-server.py
@@ -106,6 +106,7 @@ def format_date_time(dt=None):
 # I/O adapter: h11 <-> trio
 ################################################################
 
+
 # The core of this could be factored out to be usable for trio-based clients
 # too, as well as servers. But as a simplified pedagogical example we don't
 # attempt this here.
@@ -212,6 +213,7 @@ class TrioHTTPWrapper:
 # Server main loop
 ################################################################
 
+
 # General theory:
 #
 # If everything goes well:
@@ -275,6 +277,7 @@ async def http_serve(stream):
 ################################################################
 # Actual response handlers
 ################################################################
+
 
 # Helper function
 async def send_simple_response(wrapper, status_code, content_type, body):

--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -57,6 +57,7 @@ class PAUSED(Sentinel, metaclass=Sentinel):
 # - Apache: <8 KiB per line>
 DEFAULT_MAX_INCOMPLETE_EVENT_SIZE = 16 * 1024
 
+
 # RFC 7230's rules for connection lifecycles:
 # - If either side says they want to close the connection, then the connection
 #   must close.

--- a/h11/tests/test_connection.py
+++ b/h11/tests/test_connection.py
@@ -594,7 +594,7 @@ def test_pipelining() -> None:
 
 
 def test_protocol_switch() -> None:
-    for (req, deny, accept) in [
+    for req, deny, accept in [
         (
             Request(
                 method="CONNECT",
@@ -721,7 +721,7 @@ def test_protocol_switch() -> None:
 def test_close_simple() -> None:
     # Just immediately closing a new connection without anything having
     # happened yet.
-    for (who_shot_first, who_shot_second) in [(CLIENT, SERVER), (SERVER, CLIENT)]:
+    for who_shot_first, who_shot_second in [(CLIENT, SERVER), (SERVER, CLIENT)]:
 
         def setup() -> ConnectionPair:
             p = ConnectionPair()

--- a/h11/tests/test_io.py
+++ b/h11/tests/test_io.py
@@ -125,12 +125,12 @@ def tr(reader: Any, data: bytes, expected: Any) -> None:
 
 
 def test_writers_simple() -> None:
-    for ((role, state), event, binary) in SIMPLE_CASES:
+    for (role, state), event, binary in SIMPLE_CASES:
         tw(WRITERS[role, state], event, binary)
 
 
 def test_readers_simple() -> None:
-    for ((role, state), event, binary) in SIMPLE_CASES:
+    for (role, state), event, binary in SIMPLE_CASES:
         tr(READERS[role, state], binary, event)
 
 


### PR DESCRIPTION
The `black` version used in CI is not pinned so the new version's formatting needs to be applied to `master`.