### PR TITLE
Add support for Python 3.11 and 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,13 @@ jobs:
       max-parallel: 7
       matrix:
         python-version:
-        - 3.7
         - 3.8
         - 3.9
         - "3.10"
         - "3.11"
         - "3.12"
-        - pypy-3.7
-        - pypy-3.8
+        - pypy-3.9
+        - pypy-3.10
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,24 @@ jobs:
   tox:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      max-parallel: 7
       matrix:
         python-version:
         - 3.7
         - 3.8
         - 3.9
         - "3.10"
+        - "3.11"
+        - "3.12"
         - pypy-3.7
         - pypy-3.8
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install tox
       run: |
         python -m pip install --upgrade pip setuptools
@@ -35,6 +38,6 @@ jobs:
     - name: Test with tox
       run: |
         tox --parallel 0
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ library.
 It has a test suite with 100.0% coverage for both statements and
 branches.
 
-Currently it supports Python 3 (testing on 3.7-3.10) and PyPy 3.
+Currently it supports Python 3 (testing on 3.8-3.12) and PyPy 3.
 The last Python 2-compatible version was h11 0.11.x.
 (Originally it had a Cython wrapper for `http-parser
 <https://github.com/nodejs/http-parser>`_ and a beautiful nested state

--- a/bench/benchmarks/benchmarks.py
+++ b/bench/benchmarks/benchmarks.py
@@ -60,7 +60,7 @@ def _run_basic_get_repeatedly():
         for _ in range(REPEAT):
             time_server_basic_get_with_realistic_headers()
         finish = default_timer()
-        print("{:.1f} requests/sec".format(REPEAT / (finish - start)))
+        print(f"{REPEAT / (finish - start):.1f} requests/sec")
 
 
 if __name__ == "__main__":

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # h11 documentation build configuration file, created by
 # sphinx-quickstart on Tue May  3 00:20:14 2016.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ whatever. But h11 makes it much easier to implement something like
 Vital statistics
 ----------------
 
-* Requirements: Python 3.7+ (PyPy works great)
+* Requirements: Python 3.8+ (PyPy works great)
 
   The last Python 2-compatible version was h11 0.11.x.
 

--- a/docs/source/make-state-diagrams.py
+++ b/docs/source/make-state-diagrams.py
@@ -38,16 +38,16 @@ class Edges:
 
     def e(self, source, target, label, color, italicize=False, weight=1):
         if italicize:
-            quoted_label = "<<i>{}</i>>".format(label)
+            quoted_label = f"<<i>{label}</i>>"
         else:
-            quoted_label = '<{}>'.format(label)
+            quoted_label = f'<{label}>'
         self.edges.append(
-            '{source} -> {target} [\n'
-            '  label={quoted_label},\n'
-            '  color="{color}", fontcolor="{color}",\n'
-            '  weight={weight},\n'
-            ']\n'
-            .format(**locals()))
+            f'{source} -> {target} [\n'
+            f'  label={quoted_label},\n'
+            f'  color="{color}", fontcolor="{color}",\n'
+            f'  weight={weight},\n'
+            f']\n'
+            )
 
     def write(self, f):
         self.edges.sort()
@@ -150,7 +150,7 @@ def make_dot(role, out_path):
             else:
                 (their_state, our_state) = state_pair
             edges.e(our_state, updates[role],
-                    "<i>peer in</i><BR/>{}".format(their_state),
+                    f"<i>peer in</i><BR/>{their_state}",
                     color=_STATE_COLOR)
 
         if role is CLIENT:

--- a/examples/trio-server.py
+++ b/examples/trio-server.py
@@ -118,7 +118,7 @@ class TrioHTTPWrapper:
         self.conn = h11.Connection(h11.SERVER)
         # Our Server: header
         self.ident = " ".join(
-            ["h11-example-trio-server/{}".format(h11.__version__), h11.PRODUCT_ID]
+            [f"h11-example-trio-server/{h11.__version__}", h11.PRODUCT_ID]
         ).encode("ascii")
         # A unique id for this connection, to include in debugging output
         # (useful for understanding what's going on if there are multiple
@@ -206,7 +206,7 @@ class TrioHTTPWrapper:
 
     def info(self, *args):
         # Little debugging method
-        print("{}:".format(self._obj_id), *args)
+        print(f"{self._obj_id}:", *args)
 
 
 ################################################################
@@ -253,7 +253,7 @@ async def http_serve(stream):
                 if type(event) is h11.Request:
                     await send_echo_response(wrapper, event)
         except Exception as exc:
-            wrapper.info("Error during response handler: {!r}".format(exc))
+            wrapper.info(f"Error during response handler: {exc!r}")
             await maybe_send_error_response(wrapper, exc)
 
         if wrapper.conn.our_state is h11.MUST_CLOSE:
@@ -268,7 +268,7 @@ async def http_serve(stream):
                 states = wrapper.conn.states
                 wrapper.info("unexpected state", states, "-- bailing out")
                 await maybe_send_error_response(
-                    wrapper, RuntimeError("unexpected state {}".format(states))
+                    wrapper, RuntimeError(f"unexpected state {states}")
                 )
                 await wrapper.shutdown_and_clean_up()
                 return
@@ -343,7 +343,7 @@ async def send_echo_response(wrapper, request):
 
 
 async def serve(port):
-    print("listening on http://localhost:{}".format(port))
+    print(f"listening on http://localhost:{port}")
     try:
         await trio.serve_tcp(http_serve, port)
     except KeyboardInterrupt:

--- a/h11/_connection.py
+++ b/h11/_connection.py
@@ -172,7 +172,7 @@ class Connection:
         self._max_incomplete_event_size = max_incomplete_event_size
         # State and role tracking
         if our_role not in (CLIENT, SERVER):
-            raise ValueError("expected CLIENT or SERVER, not {!r}".format(our_role))
+            raise ValueError(f"expected CLIENT or SERVER, not {our_role!r}")
         self.our_role = our_role
         self.their_role: Type[Sentinel]
         if our_role is CLIENT:

--- a/h11/_state.py
+++ b/h11/_state.py
@@ -358,7 +358,7 @@ class ConnectionState:
     def start_next_cycle(self) -> None:
         if self.states != {CLIENT: DONE, SERVER: DONE}:
             raise LocalProtocolError(
-                "not in a reusable state. self.states={}".format(self.states)
+                f"not in a reusable state. self.states={self.states}"
             )
         # Can't reach DONE/DONE with any of these active, but still, let's be
         # sure.

--- a/h11/tests/test_against_stdlib_http.py
+++ b/h11/tests/test_against_stdlib_http.py
@@ -104,7 +104,7 @@ class H11RequestHandler(socketserver.BaseRequestHandler):
 def test_h11_as_server() -> None:
     with socket_server(H11RequestHandler) as httpd:
         host, port = httpd.server_address
-        url = "http://{}:{}/some-path".format(host, port)
+        url = f"http://{host}:{port}/some-path"
         with closing(urlopen(url)) as f:
             assert f.getcode() == 200
             data = f.read()

--- a/h11/tests/test_connection.py
+++ b/h11/tests/test_connection.py
@@ -879,7 +879,7 @@ def test_sendfile() -> None:
     ) -> Tuple[Connection, Optional[List[bytes]]]:
         c = Connection(SERVER)
         receive_and_get(
-            c, "GET / HTTP/{}\r\nHost: a\r\n\r\n".format(http_version).encode("ascii")
+            c, f"GET / HTTP/{http_version}\r\nHost: a\r\n\r\n".encode("ascii")
         )
         headers = []
         if header:

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,7 @@ setup(
     # This means, just install *everything* you see under h11/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
-    python_requires=">=3.7",
-    install_requires=[
-        "typing_extensions; python_version < '3.8'",
-    ],
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -30,7 +27,6 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: System :: Networking",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = format, py37, py38, py39, py310, pypy3, mypy
+envlist = format, py{37, 38, 39, 310, 311, 312, py3}, mypy
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, format, mypy
+    3.10: py310
+    3.11: py311, format, mypy
+    3.12: py312
     pypy-3.7: pypy3
     pypy-3.8: pypy3
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,15 @@
 [tox]
-envlist = format, py{37, 38, 39, 310, 311, 312, py3}, mypy
+envlist = format, py{38, 39, 310, 311, 312, py3}, mypy
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311, format, mypy
     3.12: py312
-    pypy-3.7: pypy3
-    pypy-3.8: pypy3
+    pypy-3.9: pypy3
+    pypy-3.10: pypy3
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
