### PR TITLE
Fix _SWITCH_UPGRADE without proposal error message

### DIFF
--- a/h11/_state.py
+++ b/h11/_state.py
@@ -283,9 +283,7 @@ class ConnectionState:
             assert role is SERVER
             if server_switch_event not in self.pending_switch_proposals:
                 raise LocalProtocolError(
-                    "Received server {} event without a pending proposal".format(
-                        server_switch_event
-                    )
+                    "Received server _SWITCH_UPGRADE event without a pending proposal"
                 )
             _event_type = (event_type, server_switch_event)
         if server_switch_event is None and _event_type is Response:


### PR DESCRIPTION
When we try to switch protocols when the client has not requested it, h11 throws a `LocalProtocolError`.

Here is how h11 do it:

https://github.com/python-hyper/h11/blob/a2c68948accadc3876dffcf979d98002e4a4ed27/h11/_state.py#L284-L289

However, this exception can only be raised when the event is `_SWITCH_UPGRADE`, because another scenario was already checked here:

https://github.com/python-hyper/h11/blob/a2c68948accadc3876dffcf979d98002e4a4ed27/h11/_connection.py#L263-L268

In other words, if the server_switch_event is _SWITCH_CONNECT, we always know that such an event is being proposed.
