### PR TITLE
Add `h11/tests` back to sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE.txt README.rst notes.org tiny-client-demo.py h11/py.typed
 recursive-include docs *
-recursive-include h11/tests/data *
+recursive-include h11/tests *
 recursive-include fuzz *
 prune docs/build


### PR DESCRIPTION
In #159 the `h11/tests` directory was removed from wheels, but unfortunately it was also removed from sdists. This PR adds it back to sdists and maintains its absence in wheels.

``` shell
$ python -m build
$ tar -tf dist/h11-0.14.0+dev.tar.gz > 1.txt
$ git checkout add-tests-back
$ rm -rf *.egg-info
$ python -m build
$ tar -tf dist/h11-0.14.0+dev.tar.gz > 2.txt
$ diff -u 1.txt 2.txt
```

``` diff
@@ -45,8 +45,19 @@
 h11-0.14.0+dev/h11/_writers.py
 h11-0.14.0+dev/h11/py.typed
 h11-0.14.0+dev/h11/tests/
+h11-0.14.0+dev/h11/tests/__init__.py
 h11-0.14.0+dev/h11/tests/data/
 h11-0.14.0+dev/h11/tests/data/test-file
+h11-0.14.0+dev/h11/tests/helpers.py
+h11-0.14.0+dev/h11/tests/test_against_stdlib_http.py
+h11-0.14.0+dev/h11/tests/test_connection.py
+h11-0.14.0+dev/h11/tests/test_events.py
+h11-0.14.0+dev/h11/tests/test_headers.py
+h11-0.14.0+dev/h11/tests/test_helpers.py
+h11-0.14.0+dev/h11/tests/test_io.py
+h11-0.14.0+dev/h11/tests/test_receivebuffer.py
+h11-0.14.0+dev/h11/tests/test_state.py
+h11-0.14.0+dev/h11/tests/test_util.py
 h11-0.14.0+dev/h11.egg-info/
 h11-0.14.0+dev/h11.egg-info/PKG-INFO
 h11-0.14.0+dev/h11.egg-info/SOURCES.txt
```