### PR TITLE
Add headers.get and headers.getlist

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -128,6 +128,18 @@ have a newline inside a header value, and ``Content-Length: hello`` is
 an error because `Content-Length` should always be an integer. We may
 add additional checks in the future.
 
+It is possible to get the first or all headers for a given name.
+
+.. ipython:: python
+
+   res = h11.Response(status_code=204, headers=[
+      ("Date", b"Thu, 09 Jan 2025 18:37:23 GMT"),
+      ("Set-Cookie", b"sid=1234"),
+      ("Set-Cookie", b"lang=en_US"),
+   ])
+   res.headers.get(b"date")
+   res.headers.getlist(b"set-cookie")
+
 While we make sure to expose header names as lowercased bytes, we also
 preserve the original header casing that is used. Compliant HTTP
 agents should always treat headers in a case insensitive manner, but

--- a/h11/tests/test_events.py
+++ b/h11/tests/test_events.py
@@ -146,3 +146,19 @@ def test_header_casing() -> None:
         (b"Host", b"example.org"),
         (b"Connection", b"keep-alive"),
     ]
+
+def test_header_get() -> None:
+    r = Response(status_code=204, headers=[
+        ("Date", b"Thu, 09 Jan 2025 18:37:23 GMT"),
+        ("Set-Cookie", b"sid=1234"),
+        ("Set-Cookie", b"lang=en_US"),
+    ])
+
+    assert r.headers.get(b"date") == b"Thu, 09 Jan 2025 18:37:23 GMT"
+    assert r.headers.get(b"set-cookie") == b"sid=1234"
+    assert r.headers.get(b"content-length") is None
+    assert r.headers.get(b"content-length", b"0") == b"0"
+
+    assert r.headers.getlist(b"date") == [b"Thu, 09 Jan 2025 18:37:23 GMT"]
+    assert r.headers.getlist(b"set-cookie") == [b"sid=1234", b"lang=en_US"]
+    assert r.headers.getlist(b"content-length") == []


### PR DESCRIPTION
Hello there, first time contributing :)

I wanted to access a header value with little code, like `req.headers[b"content-type"]` but since the headers are implemented as a `Sequence` there are no easy way beside iterating all the headers to find the one that interest me.

I am not challenging the internal data-structure, `list(tuple(bytes, bytes, bytes))` is kinda the only sane structure because of headers like `Set-Cookie`.

In this work I add two helpers `get(name) -> bytes` and `getlist(name) -> list[bytes]` that searches the headers for me, so I don't have to write this `next(generator, None)` everywhere :smile: The two method names at coined at the `Headers` class of [`werkzeug`](https://werkzeug.palletsprojects.com/en/stable/datastructures/#werkzeug.datastructures.Headers.getlist). We might also add the `type=` parameter for total symmetry, you tell me.

The implementation is simple stupid, it iterates over the headers looking for one that matches the name.

I did experiment with another implementation, as follow (didn't test it):

```diff
     def __init__(self, full_items: List[Tuple[bytes, bytes, bytes]]) -> None:
         self._full_items = full_items
+        self._index = {}
+        for idx, (_, name, value) in enumerate(full_items):
+            self._index.setdefault(name, []).append(idx)
 
     def __bool__(self) -> bool:
         return bool(self._full_items)
@@ -118,6 +133,15 @@ class Headers(Sequence[Tuple[bytes, bytes]]):
         _, name, value = self._full_items[idx]
         return (name, value)
 
+    def get(self, name: bytes, default: T = None) -> Union[bytes, T]:
+        try:
+            self[self._index[name][0]][1]
+        except KeyError:
+            return default
+
+    def getlist(self, name: bytes) -> List[bytes]:
+        return [self[idx][1] for idx in self._index.get(name, ())]
```

But I don't think it deserves an index. I think the O(n) search is fine.